### PR TITLE
Section lists

### DIFF
--- a/content/gherkin/_index.md
+++ b/content/gherkin/_index.md
@@ -1,0 +1,3 @@
+---
+title: Gherkin
+---

--- a/content/welcome.md
+++ b/content/welcome.md
@@ -1,0 +1,7 @@
+---
+title: Cucumber Documentation
+---
+
+Welcome to Cucumber.
+
+* [Gherkin](/gherkin/)

--- a/themes/cucumber-hugo/layouts/_default/section.html
+++ b/themes/cucumber-hugo/layouts/_default/section.html
@@ -1,3 +1,10 @@
+{{ partial "header.html" . }}
+{{ partial "nav.html" . }}
+{{ partial "menu-content" . }}
+
+
+Test
+
 {{ define "main" }}
   <main>
       {{ .Content }}
@@ -13,3 +20,5 @@
       {{ partial "pagination.html" . }}
   </main>
 {{ end }}
+
+{{ partial "footer.html" . }}

--- a/themes/cucumber-hugo/layouts/partials/menu.html
+++ b/themes/cucumber-hugo/layouts/partials/menu.html
@@ -21,27 +21,6 @@
 
 <aside class="menu">
   <p class="menu-label">
-    Implementations
-  </p>
-  <ul class="menu-list">
-    {{ $currentPage := . }}
-    {{ range .Site.Menus.implementations }}
-      <li>
-        <a href="{{.URL}}"{{if $currentPage.IsMenuCurrent "implementations" . }} class="is-active"{{end}}>
-          {{ .Pre }}
-          <span>{{ .Name }}</span>
-        </a>
-
-        {{if $currentPage.IsMenuCurrent "implementations" . }}
-          {{ $currentPage.TableOfContents }}
-        {{end}}
-      </li>
-    {{end}}
-  </ul>
-</aside>
-
-<aside class="menu">
-  <p class="menu-label">
     Gherkin
   </p>
   <ul class="menu-list">
@@ -75,6 +54,27 @@
         </a>
 
         {{if $currentPage.IsMenuCurrent "reference" . }}
+          {{ $currentPage.TableOfContents }}
+        {{end}}
+      </li>
+    {{end}}
+  </ul>
+</aside>
+
+<aside class="menu">
+  <p class="menu-label">
+    Implementations
+  </p>
+  <ul class="menu-list">
+    {{ $currentPage := . }}
+    {{ range .Site.Menus.implementations }}
+      <li>
+        <a href="{{.URL}}"{{if $currentPage.IsMenuCurrent "implementations" . }} class="is-active"{{end}}>
+          {{ .Pre }}
+          <span>{{ .Name }}</span>
+        </a>
+
+        {{if $currentPage.IsMenuCurrent "implementations" . }}
           {{ $currentPage.TableOfContents }}
         {{end}}
       </li>

--- a/themes/cucumber-hugo/layouts/partials/nav.html
+++ b/themes/cucumber-hugo/layouts/partials/nav.html
@@ -26,7 +26,7 @@
     </span>
 
     <div id="nav-menu" class="nav-right nav-menu">
-      <a class="nav-item " href="/introduction_to_cucumber_and_bdd/">
+      <a class="nav-item " href="/welcome/">
         Documentation
       </a>
       <a class="nav-item " href="https://cucumber.io/blog">


### PR DESCRIPTION
This does not yet work. But we need it. 

Ie, we should be able to have a welcome page, pointing to the various sections, with lists of the pages in Gherkin, Cucumber, etc. 