### PR TITLE
Add links

### DIFF
--- a/content/about/contributing.md
+++ b/content/about/contributing.md
@@ -9,16 +9,16 @@ Please follow these guidelines if you want to contribute to Cucumber or help the
 
 ## You have found a bug
 
-Before you [[get in touch]] and file a ticket in the issue tracker, make sure you have tried the latest gem. Also try to \[\[install]] the latest code from Git. This way you don't waste the developers' time by reporting a bug that has already been fixed.
+Before you [get in touch](/about/get-in-touch) and file a ticket in the issue tracker, make sure you have tried the latest gem. Also try to \[\[install]] the latest code from Git. This way you don't waste the developers' time by reporting a bug that has already been fixed.
 
 If you are certain you have found a bug, just register a ticket. If you're not sure, please ask on the mailing list first.
 
 ### Help us fix it
 
-The only way we can fix a bug is to reproduce it first. If reproducing the bug requires setting up a project, please write a [[Cucumber Feature]] that demonstrates the bug. When you have done that, mention it in your ticket or send a pull request.
+The only way we can fix a bug is to reproduce it first. If reproducing the bug requires setting up a project, please write a [Cucumber Feature](/gherkin/feature-introduction/) that demonstrates the bug. When you have done that, mention it in your ticket or send a pull request.
 
 Explain what gem you have (`gem list`), what command(s) you ran, what the output is etc.
 
 ## You want a new feature
 
-Start by creating a ticket. Then, create a [[Cucumber Feature]] and start implementing it. It also helps if you add RSpec specs for the low level code.
+Start by creating a ticket. Then, create a [Cucumber Feature](/gherkin/feature-introduction/) and start implementing it. It also helps if you add RSpec specs for the low level code.

--- a/content/about/get-in-touch.md
+++ b/content/about/get-in-touch.md
@@ -38,4 +38,4 @@ So when you ask a question, please tell us:
 - What the output, error message and full backtrace was: Feed cucumber with `--backtrace --verbose` and rake with `--trace`.
 - What output you had expected.
 - What relevant code you have. Don't *describe* your code in twelve furlongs of prose, just show it. Please don't paste code in emails, use: <http://gist.github.com/>
-- And finally, tell us how to reproduce the error, as described on the [[Contributing]] page.
+- And finally, tell us how to reproduce the error, as described on the [Contributing](/about/contributing/) page.

--- a/content/cucumber/cucumber.yml.md
+++ b/content/cucumber/cucumber.yml.md
@@ -17,7 +17,7 @@ Cucumber lets you store and reuse commonly used cucumber command line arguments 
    bvt: --tags @bvt
    ```
 
-Defining a template requires a name and then the command-line options that you want to execute with this profile. The example above generates two profiles: the first, named `html_report`, with a list of command-line options that specify new output formats and a second, named `bvt` which executes all features and scenarios [[tagged|Tags]] with @bvt.
+Defining a template requires a name and then the command-line options that you want to execute with this profile. The example above generates two profiles: the first, named `html_report`, with a list of command-line options that specify new output formats and a second, named `bvt` which executes all features and scenarios [tagged](/cucumber/tags/) with @bvt.
 
 ## Executing Profiles
 
@@ -77,7 +77,7 @@ The cucumber.yml file is preprocessed by ERb; this allows you to use ruby code t
 
 ## Environment Variables
 
-[[Environment Variables]] can be used in the profile argument list for a profile as you would normally specify one on the command-line.
+[Environment Variables](/cucumber/environment-variables/) can be used in the profile argument list for a profile as you would normally specify one on the command-line.
 
 ```yaml
 

--- a/content/cucumber/step-organization.md
+++ b/content/cucumber/step-organization.md
@@ -6,9 +6,9 @@ source: https://github.com/cucumber/cucumber/wiki/Step-Organization/
 title: Step Organization
 ---
 
-> TODO: intregrate with step definitions
+> TODO: integrate with step definitions
 
-How do you name step definition files? What to put in each step definition? What **not** to put in step definitions? Here are some guidelines that will lead to better scenarios. If you are new to steps and the general syntax, please read [[Feature Introduction]] first.
+How do you name step definition files? What to put in each step definition? What **not** to put in step definitions? Here are some guidelines that will lead to better scenarios. If you are new to steps and the general syntax, please read [Feature Introduction](/gherkin/feature-introduction/) first.
 
 ## Grouping
 

--- a/content/gherkin/feature-introduction.md
+++ b/content/gherkin/feature-introduction.md
@@ -5,14 +5,14 @@ source: https://github.com/cucumber/cucumber/wiki/Feature-Introduction/
 title: Feature Introduction
 ---
 
-> TODO: gherkin referemce
+> TODO: gherkin reference
 
 Every `.feature` file conventionally consists of a single feature. A line
 starting with the keyword **Feature** followed by free indented text starts a
 feature. A feature usually contains a list of scenarios. You can write whatever
 you want up until the first scenario, which starts with the word **Scenario**
-(or localized equivalent; Gherkin is localized for [[dozens of languages|Spoken
-languages]]) on a new line. You can use \[\[tagging|Tags]] to group features and
+(or localized equivalent; Gherkin is localized for dozens of [spoken
+languages](/gherkin/spoken-languages/) on a new line. You can use \[\[tagging|Tags]] to group features and
 scenarios together independent of your file and directory structure.
 
 Every scenario consists of a list of steps, which must start with one of the

--- a/content/gherkin/gherkin-reference.md
+++ b/content/gherkin/gherkin-reference.md
@@ -7,7 +7,7 @@ title: Gherkin Reference
 # Reference
 
 This is the general reference for all Cucumber implementations. Please refer to
-the [documentation overview](/implementations/) for links to platform-specific documentation.
+the Implementations menu for links to platform-specific documentation.
 
 ## Gherkin
 

--- a/content/gherkin/gherkin-reference.md
+++ b/content/gherkin/gherkin-reference.md
@@ -7,7 +7,7 @@ title: Gherkin Reference
 # Reference
 
 This is the general reference for all Cucumber implementations. Please refer to
-the [[documentation overview]] for links to platform-specific documentation.
+the [documentation overview](/implementations/) for links to platform-specific documentation.
 
 ## Gherkin
 

--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -11,7 +11,7 @@ Cucumber-JVM is a Cucumber implementation for the most popular JVM languages.
 
 This document is the reference for features that are specific to Cucumber-JVM.
 
-Please see the [general reference](/gherkin/) for features that are
+Please see the [general reference](/gherkin/gherkin-reference/) for features that are
 common to all Cucumber implementations.
 
 ## Languages

--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -11,7 +11,7 @@ Cucumber-JVM is a Cucumber implementation for the most popular JVM languages.
 
 This document is the reference for features that are specific to Cucumber-JVM.
 
-Please see the [[general reference]] for features that are
+Please see the [general reference](/gherkin/) for features that are
 common to all Cucumber implementations.
 
 ## Languages

--- a/content/implementations/php.md
+++ b/content/implementations/php.md
@@ -92,7 +92,7 @@ and reload it at the end so that next time it will be the same, or you can do it
 on a per feature level and per database table level. I have so far found the
 second approach to be the quickest and most flexible.
 
-The per feature and per table approach can be accomplished using [[hooks]].
+The per feature and per table approach can be accomplished using [hooks](/cucumber/hooks/).
 Here are is the code that I currently have in 'support/hooks.rb'
 
 ```


### PR DESCRIPTION
Partial fix for https://github.com/cucumber/docs.cucumber.io/issues/19

Several links still need to be added (or removed), but I couldn't find anything to link to:
* implementations/jvm.md:
[[Android Runner]] - 4x
[[Data Table]] - 2x
* cucumber.yml.md
[[Integration with Autotest|Autotest-Integration]]
* gherkin-reference.md
[[Multiline Step Arguments]] - 2x