### PR TITLE
Add/fix links and fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ public/
 venv
 *.swp
 Gemfile.lock
+/.idea/

--- a/content/about/blog-posts.md
+++ b/content/about/blog-posts.md
@@ -7,7 +7,7 @@ title: Blog Posts about Cucumber
 
 Here is a list of Cucumber related blog posts/tutorials. Please keep in mind that blogs can become dated quickly with a fast moving project like Cucumber. Cucumber's RDocs and wiki should be considered the canonical documentation source with the, hopefully, most up to date information. Some blog posts may refer to the RSpec Story Runner but they still provide value since Cucumber started out as a rewrite of that project.
 
-Please add any helpful blog posts that you have found or written about all things Cucumber. Also see [[Related Tools]].
+Please add any helpful blog posts that you have found or written about all things Cucumber. Also see [Related Tools](/about/related-tools/).
 
 |                                                                                                                                                                                                                                                                         |                                                                                                                                                       |                    |
 |:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------|

--- a/content/cucumber/continuous-integration.md
+++ b/content/cucumber/continuous-integration.md
@@ -43,8 +43,7 @@ If you're using Ant, you can run cucumber with the [`exec`](https://ant.apache.o
 
 A Jenkins plugin is available that produces beautiful Cucumber reports.
 
-Follow the install instructions here:
-<https://github.com/jenkinsci/cucumber-reports-plugin>
+Follow the install instructions [here](https://github.com/jenkinsci/cucumber-reports-plugin).
 
 Overview Page:
 

--- a/content/cucumber/continuous-integration.md
+++ b/content/cucumber/continuous-integration.md
@@ -43,7 +43,7 @@ If you're using Ant, you can run cucumber with the [`exec`](https://ant.apache.o
 
 A Jenkins plugin is available that produces beautiful Cucumber reports.
 
-Follow the install instructions [here](https://github.com/jenkinsci/cucumber-reports-plugin).
+Follow the install instructions for [Cucumber Reports plugin](https://github.com/jenkinsci/cucumber-reports-plugin).
 
 Overview Page:
 

--- a/content/cucumber/cucumber.yml.md
+++ b/content/cucumber/cucumber.yml.md
@@ -24,7 +24,7 @@ want to execute with this profile.
 The example above generates two profiles: 
 
 1. `html_report`, with a list of command-line options that specify new output formats, and 
-2. `bvt`, which executes all Features and Scenarios [[tagged|Tags]] with `@bvt`.
+2. `bvt`, which executes all Features and Scenarios [tagged](/cucumber/tags/) with `@bvt`.
 
 ## Executing Profiles
 
@@ -107,5 +107,6 @@ So, if you have several profiles with similar values, you might do this:
 
 ## Autotest Profiles
 
-[[Integration with Autotest|Autotest-Integration]] uses two profiles: `autotest` and `autotest-all`. 
+cucumber.yml - [Autotest Integration](/wiki/autotest-integration)
+ uses two profiles: `autotest` and `autotest-all`.
 These profile names should be reserved for that service.

--- a/content/cucumber/feature-coupled-step-definitions-antipattern.md
+++ b/content/cucumber/feature-coupled-step-definitions-antipattern.md
@@ -2,7 +2,7 @@
 menu:
 - reference
 source: https://github.com/cucumber/cucumber/wiki/Feature-Coupled-Step-Definitions-(Antipattern)/
-title: Feature Coupled Step Definitions (Antipattern)
+title: Feature Coupled Step Definitions (Anti-pattern)
 ---
 
 > TODO: Generalize. Move to Step Definitions

--- a/content/cucumber/hooks.md
+++ b/content/cucumber/hooks.md
@@ -129,7 +129,7 @@ end
 **Think twice before you use Hooks!** 
 Whatever happens in Hooks is invisible to people who only read the Features. 
 You should consider using [Background](/gherkin/background/) as a more explicit 
-alternative, expecially if the setup should be readable by non-technical people.
+alternative, especially if the setup should be readable by non-technical people.
 
 ## Global Hooks
 
@@ -177,4 +177,4 @@ end
 
 This Hook will run _only once_: after support has been loaded, and before any Features are loaded. 
 
-You can use this Hook to extend Cucumber. For example you could affect how Features are loaded, or register [custom formatters](/implementations/ruby/custom-formatters/) programatically.
+You can use this Hook to extend Cucumber. For example you could affect how Features are loaded, or register [custom formatters](/implementations/ruby/custom-formatters/) programmatically.

--- a/content/cucumber/running-features.md
+++ b/content/cucumber/running-features.md
@@ -71,8 +71,8 @@ See the [`Cucumber.tmbundle`](https://github.com/cucumber/cucumber-tmbundle) doc
 
 ## Using other build tools
 
-Maven and Ant are described in [[JRuby and Java]]. 
+Maven and Ant are described in [JRuby](/implementations/jvm/#jruby) and [Java](/implementations/jvm/#java).
 
-MSBuild and Nant should be under [[IronRuby and .NET]]. 
+MSBuild and Nant should be under [[IronRuby]] and [.NET](/implementations/dotnet-specflow/).
 
 Anything else? Please contribute to this wiki!

--- a/content/cucumber/running-features.md
+++ b/content/cucumber/running-features.md
@@ -73,6 +73,6 @@ See the [`Cucumber.tmbundle`](https://github.com/cucumber/cucumber-tmbundle) doc
 
 Maven and Ant are described in [JRuby](/implementations/jvm/#jruby) and [Java](/implementations/jvm/#java).
 
-MSBuild and Nant should be under [[IronRuby]] and [.NET](/implementations/dotnet-specflow/).
+MSBuild and Nant should be under [IronRuby](http://ironruby.net/) and [.NET](/implementations/dotnet-specflow/).
 
 Anything else? Please contribute to this wiki!

--- a/content/cucumber/state.md
+++ b/content/cucumber/state.md
@@ -60,8 +60,8 @@ Feature: Let's write a lot of stuff to the DB
 
 The [`cucumber-spring`](/implementations/jvm/java-di/#spring) module contains `@txn` Hooks in the `cucumber.api.spring` package.
 
-This package isn't on your [[glue path]] by default, so you have to add it yourself in your
-[[Configuration Options]].
+This package isn't on your glue path by default, so you have to add it yourself in your
+Configuration Options.
 
 ```java
 @RunWith(Cucumber.class)

--- a/content/cucumber/state.md
+++ b/content/cucumber/state.md
@@ -21,9 +21,9 @@ Make sure you clean your database between Scenarios.
 ### The Before Hook Approach
 
 The recommended approach to clean a database between Scenarios is to use a
-[[Before Hook]] to remove all data *before* a Scenario starts.
+`Before`[Hook](/cucumber/hooks/) to remove all data *before* a Scenario starts.
 
-This is usually better than using an [[After Hook]], as it allows
+This is usually better than using an `After`[Hook](/cucumber/hooks/), as it allows
 you to perform a post-mortem inspection of the database if a Scenario fails.
 
 An alternative approach is to use database transactions.
@@ -36,13 +36,13 @@ You can wrap a transaction (if your database supports it) *around* each Scenario
 You won't be able to perform a post-mortem, and you won't be able to 
 use [browser automation](/cucumber/browser-automation/)).
 
-You simply tell Cucumber to start a transaction in a [[Before Hook]], and later 
-roll it back in an [[After Hook]].
+You simply tell Cucumber to start a transaction in a `Before`[Hook](/cucumber/hooks/), and later
+roll it back in an `After`[Hook](/cucumber/hooks/).
 
 This is such a common thing to do that several Cucumber extensions provide ready-to-use
-[[Tagged Hooks]] using a Tag named `@txn`.
+[Tagged Hooks](/cucumber/hooks/#tagged-hooks) using a Tag named `@txn`.
 
-To enable it, you must tag every [[Feature]] or [[Scenario]] that requires 
+To enable it, you must tag every [Feature](/gherkin/feature-introduction/) or [Scenario](/gherkin/gherkin-reference/#scenario) that requires
 transactions with `@txn`:
 
 ```gherkin
@@ -58,7 +58,7 @@ Feature: Let's write a lot of stuff to the DB
 
 ### Using JUnit and Spring
 
-The [[`cucumber-spring`]] module contains `@txn` Hooks in the `cucumber.api.spring` package.
+The [`cucumber-spring`](/implementations/jvm/java-di/#spring) module contains `@txn` Hooks in the `cucumber.api.spring` package.
 
 This package isn't on your [[glue path]] by default, so you have to add it yourself in your
 [[Configuration Options]].

--- a/content/cucumber/step-definitions.md
+++ b/content/cucumber/step-definitions.md
@@ -69,7 +69,7 @@ Steps are declared in your `features/\*.feature` files.
 3. Cucumber passes them to the Step Definition's `Proc` (or “function”) and executes it
 
 
-Recall that Step Definitions start with a [preposition][preposition] or an [adverb][adverb] (**`Given`**, **`When`**, **`Then`**, **`And`**, **`But`**). and can be expressed in any of Cucumber's supported [spoken languages](/gherkin/spoken-languages/). 
+Recall that Step Definitions start with a [preposition](http://www.merriam-webster.com/dictionary/given) or an [adverb](http://www.merriam-webster.com/dictionary/when) (**`Given`**, **`When`**, **`Then`**, **`And`**, **`But`**). and can be expressed in any of Cucumber's supported [spoken languages](/gherkin/spoken-languages/).
 
 All Step Definitions are loaded (and defined) before Cucumber starts to execute the plain text.  
 
@@ -79,8 +79,6 @@ The specific preposition/adverb used has **no** significance when Cucumber is re
 
 Also, check out [[Multiline Step Arguments]] for more info on how to pass entire tables or bigger strings to your Step Definitions.
 
-[preposition]: http://www.merriam-webster.com/dictionary/given
-[adverb]: http://www.merriam-webster.com/dictionary/when
 
 ## Successful Steps
 

--- a/content/cucumber/tags.md
+++ b/content/cucumber/tags.md
@@ -61,7 +61,7 @@ Another creative way to use tags is to keep track of where in the development pr
 Feature: Index projects
 ```
 
-Tags are also used in Tagged [Hooks](/cucumber/hooks/), which allow you to use tags to define `Before` and/or `After` blocks to run for marked Scenarios.
+Tags are also used in [Tagged Hooks](/cucumber/hooks/#tagged-hooks), which allow you to use tags to define `Before` and/or `After` blocks to run for marked Scenarios.
 
 ## Logically `AND`-ing and `OR`-ing Tags
 

--- a/content/gherkin/background.md
+++ b/content/gherkin/background.md
@@ -41,7 +41,7 @@ When I try to post to "Expensive Therapy"
 Then I should see "Your article was published."
 ```
 
-For a less explicit alternative to Background, check out Tagged [Hooks](/cucumber/hooks/).
+For a less explicit alternative to Background, check out [Tagged Hooks](/cucumber/hooks/#tagged-hooks).
 
 ## Good practices for using Background
 

--- a/content/gherkin/conjunction-steps-antipattern.md
+++ b/content/gherkin/conjunction-steps-antipattern.md
@@ -2,7 +2,7 @@
 menu:
 - gherkin
 source: https://github.com/cucumber/cucumber/wiki/Conjunction-Steps-(Antipattern)/
-title: Conjunction Steps (Antipattern)
+title: Conjunction Steps (Anti-pattern)
 ---
 
 From the online Merriam-Webster dictionary:

--- a/content/implementations/perl.md
+++ b/content/implementations/perl.md
@@ -7,7 +7,7 @@ title: Perl
 
 > TODO: Review
 
-Writing Cucumber Tests in Perl rather than ruby
+Writing Cucumber Tests in Perl rather than Ruby
 
 **Test::BDD::Cucumber**
 

--- a/content/implementations/ruby/ruby-on-rails.md
+++ b/content/implementations/ruby/ruby-on-rails.md
@@ -80,7 +80,7 @@ Cucumber-Rails needs to add a few files to your project:
 ruby script/generate cucumber
 ```
 
-If you're on an OS that supports fork we recommend you use [[Spork and --drb]] as this lets you start cucumber faster:
+If you're on an OS that supports fork we recommend you use [Spork](https://github.com/sporkrb/spork) and '--drb'] as this lets you start cucumber faster:
 
 ```
 ruby script/generate cucumber --spork
@@ -173,7 +173,7 @@ html: --format html --out features.html
 
 ### Special tags
 
-There are two special [tags](/cucumber/tags) you can use to change how Cucumber runs your scenarios
+There are two special [tags](/cucumber/tags) you can use to change how Cucumber runs your scenarios:
 
 #### @no-txn
 

--- a/content/implementations/ruby/ruby-on-rails.md
+++ b/content/implementations/ruby/ruby-on-rails.md
@@ -160,7 +160,7 @@ default: --format pretty
 html: --format html --out features.html
 ```
 
-Remember that you need AUTOFEATURE=true for autospec to include cucumber features. See [[Running Features]] and \[\[Autotest Integration]] for more info.
+Remember that you need AUTOFEATURE=true for autospec to include cucumber features. See [Running Features](/cucumber/running-features) and [Autotest Integration](/wiki/autotest-integration) for more info.
 
 For autospec, change autotest in the above block to autospec:
 
@@ -173,11 +173,12 @@ html: --format html --out features.html
 
 ### Special tags
 
-There are two special [[tags]] you can use to change how Cucumber runs your scenarios
+There are two special [tags](/cucumber/tags) you can use to change how Cucumber runs your scenarios
 
 #### @no-txn
 
-By default all scenarios will run within a database transaction that is rolled back at the end. However, scenarios tagged with `@no-txn` will run **without** a transaction. This can be useful when you have to deal with [[Browsers and Transactions]]. Beware that this will leave data in your database after that scenario, which can lead to hard-to-debug failures in subsequent scenarios. If you use this, we recommend you create a Before block that will explicitly put your database in a known state, for example using [DatabaseCleaner](https://github.com/bmabey/database_cleaner)
+By default all scenarios will run within a database transaction that is rolled back at the end. However, scenarios tagged with `@no-txn` will run **without** a transaction. This can be useful when you have to deal with [Browsers and Transactions](/implementations/ruby/browsers-and-transactions).
+Beware that this will leave data in your database after that scenario, which can lead to hard-to-debug failures in subsequent scenarios. If you use this, we recommend you create a Before block that will explicitly put your database in a known state, for example using [DatabaseCleaner](https://github.com/bmabey/database_cleaner)
 
 #### @allow-rescue
 

--- a/content/introduction_to_cucumber_and_bdd.md
+++ b/content/introduction_to_cucumber_and_bdd.md
@@ -18,8 +18,8 @@ bonus feature — when it yells in red, it's talking to you, telling you what co
 you should write.
 
 Gherkin's grammar is defined in the Treetop grammar that is part of the Cucumber
-codebase. The grammar exists in different flavours for many spoken
-languages (60 at the time of writing), so that your team can use the
+codebase. The grammar exists in different flavours for many [spoken
+languages](/gherkin/spoken-languages/) (60 at the time of writing), so that your team can use the
 keywords in your own language.
 
 There are a few conventions:
@@ -38,8 +38,8 @@ Each Scenario is a list of Steps for Cucumber to work through. So that Cucumber
 can understand these Feature files, they must follow some basic syntax rules.
 The name for this set of rules is [Gherkin](/gherkin/gherkin-intro/).
 
-Along with the Features, you give Cucumber a set of Step Definitions. These
-files map each business-readable language step into programming code to carry
+Along with the [Features](/gherkin/feature-introduction/), you give Cucumber a set of [Step Definitions](/cucumber/step-definitions/). These
+files map (or "glue") each business-readable language step into programming code to carry
 out what action should be performed by the Step. 
 
 In a mature test suite, the Step Definition itself will probably just be one or two lines of code that delegate to a library of support code, specific to the domain of your application.
@@ -59,11 +59,11 @@ their own ubiquitous language for talking about their problem domain. This helps
 
 # How does Cucumber work with BDD?
 
-This is the most typical question for every enthusiastic personality would get.
-What makes Cucumber to stand out from the crowd of other communication and
+This is the most typical question everyone enthusiastic about Cucumber will get.
+What makes Cucumber stand out from the crowd of other communication and
 collaboration tools?
 
-Cucumber has designed specifically to ensure the acceptance tests can easily be
+Cucumber was designed specifically to ensure the acceptance tests can easily be
 read and written by anyone on the team. This reveals the true value of
 acceptance tests: as a communication and collaboration tool. The easy
 readability of Cucumber tests draws business stakeholders into the process,
@@ -72,7 +72,7 @@ helping you really explore and understand the requirements.
 Cucumber was designed specifically to help business stakeholders get involved in
 writing acceptance tests.
 
-Related test cases in Cucumber are grouped into *Features*. Each test case in a Feature is called a *Scenario*. Each Scenario contains several Steps. 
+Related test cases in Cucumber are grouped into *Features*. Each test case in a Feature is called a *Scenario*. Each Scenario contains several Steps.
 
 The business-facing parts of a Cucumber test suite, stored in Feature files, must be written according to syntax rules—known as Gherkin—so that Cucumber can read them. Under the hood, Step Definitions translate the business-facing language of Steps into runnable programming code.
 
@@ -246,7 +246,7 @@ covers what a non-programmer needs to know.
 It is preferable that the first draft of any Feature be written by, or with, a
 “domain expert”. This person is typically a non-programmer, and always someone who knows the Feature's domain from a user or business perspective.
 
-Thenm the programmer(s) will go over the Scenarios, refining the Steps for
+Then the programmer(s) will go over the Scenarios, refining the Steps for
 clarification and increased testability. The result is then reviewed by the domain expert to ensure the intent has not been compromised by the programmers’
 reworking. 
 

--- a/content/tutorial/getting-started-with-cucumber-jvm-in-five-minutes.md
+++ b/content/tutorial/getting-started-with-cucumber-jvm-in-five-minutes.md
@@ -14,7 +14,7 @@ You will need the following:
 
 - [Maven](https://maven.apache.org/index.html)
 
-- Cucumber-JVM
+- [Cucumber-JVM](https://github.com/cucumber/cucumber-jvm)
 
 - An IDE editor, for example [IntelliJ  IDEA](https://www.jetbrains.com/idea/?fromMenu#chooseYourEdition) (which will be used in this
   introduction)

--- a/content/wiki/autotest-integration.md
+++ b/content/wiki/autotest-integration.md
@@ -54,7 +54,7 @@ autotest-all: --color
 
 Please see [Running Features](/cucumber/running-features/) for more information about profiles, and the [Ruby on Rails](/implementations/ruby/ruby-on-rails/) page for extra help when running in that context.
 
-If you get an error like `When using several—format options only one of them can be without a file (RuntimeError)` when running features with autospec, you are probably accidentally requiring 'spec'. Read about the solution on [[Troubleshooting]].
+If you get an error like `When using several—format options only one of them can be without a file (RuntimeError)` when running features with autospec, you are probably accidentally requiring 'spec'. Read about the solution on Troubleshooting.
 
 ### What does it do?
 

--- a/content/wiki/cucumber-backgrounder.md
+++ b/content/wiki/cucumber-backgrounder.md
@@ -361,7 +361,7 @@ For Cucumber features, the keywords used here are **Feature**, **Scenario**, **G
 
 To date ( <time datetime="2015-06-03">2015 Jun 05</time> ) the `Feature` statement and its descriptive text block are not parsed by Cucumber other than as an identifier and documentation. Nonetheless, the `Feature` statement arguably contains the most important piece of information contained in a feature file. It is here that you answer the question of just why this work is being done. And if you do not have a very good, defensible, reason that can be elucidated in a few sentences then you probably should not be expending any effort on this feature at all. First and foremost, **BDD** absolutely **must** have some concrete business value whose realization can be measured before you write a single line of code. See [Pop the 'Why?' Stack](http://www.mattblodgett.com/2009/01/pop-stack.html).
 
-As with `Feature`, `Scenario` is used only for identification when reporting failures and to document a piece of the work. The clauses (*steps*) that make up a Scenario each begin with one of: Given, When, Then, And and But (and sometimes **\***). These are all [[Gherkin]] keywords / Cucumber methods that take as their argument the string that follows. They are the steps that Cucumber will report as passing, failing or pending based on the results of the corresponding step matchers in the step_definitions.rb files. The five keywords (and **\***) are all equivalent to one another and completely interchangeable.
+As with `Feature`, `Scenario` is used only for identification when reporting failures and to document a piece of the work. The clauses (*steps*) that make up a Scenario each begin with one of: Given, When, Then, And and But (and sometimes **\***). These are all [Gherkin](/gherkin/gherkin-intro) keywords / Cucumber methods that take as their argument the string that follows. They are the steps that Cucumber will report as passing, failing or pending based on the results of the corresponding step matchers in the step_definitions.rb files. The five keywords (and **\***) are all equivalent to one another and completely interchangeable.
 
 ### What are Step Definitions?
 
@@ -486,7 +486,7 @@ When /my matcher named (.*)/ do |match|
 end
 ```
 
-Always keep in mind that Cucumber is simply a DSL wrapper around the Ruby language whose full expressiveness remains available to you in the step definition files (*but not in the feature files*). On the other hand, do not lose sight that every step called as such in a step definition file is first parsed by [[Gherkin]] and therefore must conform to the same syntax as used in feature files.
+Always keep in mind that Cucumber is simply a DSL wrapper around the Ruby language whose full expressiveness remains available to you in the step definition files (*but not in the feature files*). On the other hand, do not lose sight that every step called as such in a step definition file is first parsed by [Gherkin](/gherkin/gherkin-intro) and therefore must conform to the same syntax as used in feature files.
 
 Returning to our example of "Bob" the user, one could define things in the `step_definitions` file like this:
 


### PR DESCRIPTION
#Partial fix for https://github.com/cucumber/docs.cucumber.io/issues/19

Add / fix all the links I could find a place to link to. Just leaves the following: 
* implementations/jvm.md:
[[Android Runner]] - 4x
[[Data Table]] - 2x
* gherkin-reference.md
[[Multiline Step Arguments]] - 2x
* cucumber/running-features.md
[[IronRuby]]
* cucumber/state.md
[[glue path]]
[[Configuration Options]]
* cucumber/step-definitions
[[Multiline Step Arguments]] 
* ruby/calling-steps-from-stepdefinitions
[[Multiline Step Arguments]]
* ruby/ruby-on-rails [Spork and --drb]] 
* wiki/autotest-integration 
[[Troubleshooting]]

Suggestions to fix remaining:
1. Add info on Android runner (but not by me)
2. Add file on Multiline Step Arguments, including Data Tables (unless this was intentionally left out / removed?)
3. Remove links to IronRuby, glue path, Configuration Options, Spork and --drd, Troubleshooting (unless someone can tell me what they should point to)
