### PR TITLE
PR to fix all remaining links (add info OR remove link) for issue #19

### DIFF
--- a/content/cucumber/step-definitions.md
+++ b/content/cucumber/step-definitions.md
@@ -77,7 +77,7 @@ Once plain text execution begins, for each Step, Cucumber will look for a regist
 
 The specific preposition/adverb used has **no** significance when Cucumber is registering or looking up Step Definitions.
 
-Also, check out Multiline [Step Arguments](#step-arguments) for more info on how to pass entire tables or bigger strings to your Step Definitions.
+Also, check out Multiline [Step Arguments](/gherkin/gherkin-reference/#step-arguments) for more info on how to pass entire tables or bigger strings to your Step Definitions.
 
 
 ## Successful Steps

--- a/content/cucumber/step-definitions.md
+++ b/content/cucumber/step-definitions.md
@@ -77,7 +77,7 @@ Once plain text execution begins, for each Step, Cucumber will look for a regist
 
 The specific preposition/adverb used has **no** significance when Cucumber is registering or looking up Step Definitions.
 
-Also, check out [[Multiline Step Arguments]] for more info on how to pass entire tables or bigger strings to your Step Definitions.
+Also, check out Multiline [Step Arguments](#step-arguments) for more info on how to pass entire tables or bigger strings to your Step Definitions.
 
 
 ## Successful Steps

--- a/content/gherkin/gherkin-reference.md
+++ b/content/gherkin/gherkin-reference.md
@@ -188,7 +188,7 @@ Given <I'm a placeholder and I'm ok>
 
 The placeholders indicate that when the Examples row is run, they should be substituted with real values from the `Examples` table. If a placeholder name is the same as a column title in the `Examples` table, that is the value that will replace it.
 
-You can also use placeholders in [[Multiline Step Arguments]].
+You can also use placeholders in Multiline [Step Arguments](#step-arguments).
 
 **IMPORTANT:** *Your Step Definitions will never have to match a placeholder. They will need to match the values that will _replace_ the placeholder.*
 
@@ -265,8 +265,8 @@ For this purpose Gherkin has Doc Strings and Data Tables:
 Doc Strings are handy for passing a larger piece of text to a step definition. The syntax is inspired from Python's Docstring syntax.
 
 The text should be offset by delimiters consisting of three double-quote marks on lines of their own:
-
-```Given a blog post named "Random" with Markdown body
+```gherkin
+Given a blog post named "Random" with Markdown body
   """
   Some Title, Eh?
   ===============
@@ -276,13 +276,14 @@ The text should be offset by delimiters consisting of three double-quote marks o
 ```
 In your Step Definition, there’s no need to find this text and match it in your pattern. It will automatically be passed as the last parameter in the step definition.
 
-Indentation of the opening """ is unimportant, although common practice is two spaces in from the enclosing step. The indentation inside the triple quotes, however, is significant. Each line of the Doc String will be de-indented according to the opening """. Indentation beyond the column of the opening """ will therefore be preserved.
+Indentation of the opening '"""' is unimportant, although common practice is two spaces in from the enclosing step. The indentation inside the triple quotes, however, is significant. Each line of the Doc String will be de-indented according to the opening """. Indentation beyond the column of the opening """ will therefore be preserved.
 
 ### Data Tables
 
 Data Tables are handy for passing a list of values to a step definition:
 
-```Given the following users exist:
+```gherkin
+Given the following users exist:
   | name   | email              | twitter         |
   | Aslak  | aslak@cucumber.io  | @aslak_hellesoy |
   | Julien | julien@cucumber.io | @jbpros         |

--- a/content/gherkin/gherkin-reference.md
+++ b/content/gherkin/gherkin-reference.md
@@ -254,3 +254,40 @@ Scenario Outline: Password validation
     | abcd     | invalid          |
     | abcd1    | valid            |
 ```
+
+## Step Arguments
+
+In some cases you might want to pass more data to a step than fits on a single line.
+For this purpose Gherkin has Doc Strings and Data Tables:
+
+### Doc Strings
+
+Doc Strings are handy for passing a larger piece of text to a step definition. The syntax is inspired from Python's Docstring syntax.
+
+The text should be offset by delimiters consisting of three double-quote marks on lines of their own:
+
+```Given a blog post named "Random" with Markdown body
+  """
+  Some Title, Eh?
+  ===============
+  Here is the first paragraph of my blog post. Lorem ipsum dolor sit amet,
+  consectetur adipiscing elit.
+  """
+```
+In your Step Definition, there’s no need to find this text and match it in your pattern. It will automatically be passed as the last parameter in the step definition.
+
+Indentation of the opening """ is unimportant, although common practice is two spaces in from the enclosing step. The indentation inside the triple quotes, however, is significant. Each line of the Doc String will be de-indented according to the opening """. Indentation beyond the column of the opening """ will therefore be preserved.
+
+### Data Tables
+
+Data Tables are handy for passing a list of values to a step definition:
+
+```Given the following users exist:
+  | name   | email              | twitter         |
+  | Aslak  | aslak@cucumber.io  | @aslak_hellesoy |
+  | Julien | julien@cucumber.io | @jbpros         |
+  | Matt   | matt@cucumber.io   | @mattwynne      |
+```
+Just like Doc Strings, Data Tables will be passed to the Step Definition as the last argument.
+
+The type of this argument will be DataTable. See the API docs for more details about how to access the rows and cells.

--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -70,7 +70,7 @@ There are several ways to run scenarios with Cucumber-JVM:
 
 - [JUnit Runner](#junit-runner)
 - [CLI Runner](#cli-runner)
-- [[Android Runner]]
+- Android Runner
 - [Third party runners](#third-party-runners)
 
 ### JUnit Runner
@@ -146,7 +146,7 @@ For example:
 java cucumber.api.cli.Main --version
 ```
 
-The [JUnit Runner](#junit-runner) and [[Android Runner]] can also pick
+The [JUnit Runner](#junit-runner) and Android Runner can also pick
 up configuration options defined via the `@CucumberOptions` annotation. For example, if
  you want to tell Cucumber to use the two formatter plugins `pretty`
 and `html`, you would specify it like this:
@@ -317,7 +317,7 @@ public void the_following_animals(List<String> animals) {
 
 See the @Delimiter annotation for details about how to define a delimiter different than `,`.
 
-If you prefer to use a [[Data Table]] to define a list you can do that too:
+If you prefer to use a [Data Table](/gherkin/gherkin-reference/#data-tables/) to define a list you can do that too:
 
 ```gherkin
 Given the following animals:

--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -317,7 +317,7 @@ public void the_following_animals(List<String> animals) {
 
 See the @Delimiter annotation for details about how to define a delimiter different than `,`.
 
-If you prefer to use a [Data Table](/gherkin/gherkin-reference/#data-tables/) to define a list you can do that too:
+If you prefer to use a [Data Table](/gherkin/gherkin-reference/#step-arguments) to define a list you can do that too:
 
 ```gherkin
 Given the following animals:

--- a/content/implementations/ruby/calling-steps-from-step-definitions.md
+++ b/content/implementations/ruby/calling-steps-from-step-definitions.md
@@ -60,7 +60,7 @@ Scenario: View last incidents
 
 ## Calling steps with multiline step arguments
 
-Sometimes you want to call a step that has been designed to take Multiline [Step Arguments](#step-arguments), for example:
+Sometimes you want to call a step that has been designed to take [Multiline Strings](#multiline-strings), for example:
 
 ### Tables
 

--- a/content/implementations/ruby/calling-steps-from-step-definitions.md
+++ b/content/implementations/ruby/calling-steps-from-step-definitions.md
@@ -60,7 +60,7 @@ Scenario: View last incidents
 
 ## Calling steps with multiline step arguments
 
-Sometimes you want to call a step that has been designed to take [[Multiline Step Arguments]], for example:
+Sometimes you want to call a step that has been designed to take Multiline [Step Arguments](#step-arguments), for example:
 
 ### Tables
 


### PR DESCRIPTION
This PR adds information about (Multiline) Step Arguments, taken (-almost- verbatim) from the current cucumber.io/docs website (https://cucumber.io/docs/reference), giving missing links for Multiline Step Arguments and Data Tables a place to point to.
Removed the links for Android Runner from implementation/jvm.md, as there is nothing to point to.
(Imho this info should be added at some point)

PR fixes all remaining links (issue #19)
