### PR TITLE
Fix amusing typo in language-specific example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,5 +51,5 @@ Use fenced code blocks to specify polyglot source code:
 Use the `{{% text %}}` shortcode around text that should only be displayed for
 a particular programming language:
 
-    The preferred build tool is {{% text "java" %}}Rake{{% /text %}}{{% text "java" %}}Yarn{{% /text %}}{{% text "java" %}}Maven{{% /text %}}.
+    The preferred build tool is {{% text "ruby" %}}Rake{{% /text %}}{{% text "javascript" %}}Yarn{{% /text %}}{{% text "java" %}}Maven{{% /text %}}.
 


### PR DESCRIPTION
I don’t know anything about your build system besides surface-level details, so I’m submitting this little fix as a PR.  :)