### PR TITLE
Update support of JVM languages

### DIFF
--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -16,16 +16,17 @@ Please see the [General Reference](/gherkin/gherkin-reference/) for functionalit
 
 ## Languages
 
-Cucumber-JVM supports the following JVM languages:
+Cucumber-JVM supports Java, Kotlin and Android.
 
-- [Java](#java)
-- [Groovy](#groovy)
-- [Scala](#scala)
-- [Clojure](#clojure)
-- [Jython](#jython)
-- [JRuby](#jruby)
-- [Rhino JavaScript](#rhino-javascript)
-- [Gosu](#gosu)
+Other JVM languages have been moved to their own repository:
+* [Clojure](https://github.com/cucumber/cucumber-jvm-clojure)
+* [Gosu](https://github.com/cucumber/cucumber-jvm-gosu)
+* [Groovy](https://github.com/cucumber/cucumber-jvm-groovy)
+* [JRuby](https://github.com/cucumber/cucumber-jvm-jruby)
+* [Jython](https://github.com/cucumber/cucumber-jvm-jython)
+* [Rhino](https://github.com/cucumber/cucumber-jvm-rhino)
+* [Scala](https://github.com/cucumber/cucumber-jvm-scala)
+
 
 ## Installation
 

--- a/content/installing_cucumber.md
+++ b/content/installing_cucumber.md
@@ -57,16 +57,16 @@ Add these dependencies to your project:
 
 ```java
     <dependency>
-        <groupId>info.cukes</groupId>
+        <groupId>io.cucumber</groupId>
         <artifactId>cucumber-java</artifactId>
-        <version>1.2.4</version>
+        <version>2.0.1</version>
         <scope>test</scope>
     </dependency>
 
     <dependency>
-        <groupId>info.cukes</groupId>
+        <groupId>io.cucumber</groupId>
         <artifactId>cucumber-junit</artifactId>
-        <version>1.2.4</version>
+        <version>2.0.1</version>
         <scope>test</scope>
     </dependency>
 ```


### PR DESCRIPTION
Most JVM languages have been removed from cucumber-jvm to their own repo.
(see: https://github.com/cucumber/cucumber-jvm)
Update the documentation in line with this change.