### PR TITLE
Fix css bug in ruby examples

### DIFF
--- a/themes/cucumber-hugo/static/css/cucumber.css
+++ b/themes/cucumber-hugo/static/css/cucumber.css
@@ -164,9 +164,6 @@ a:hover {
 }
 
 code {
-  background-color: whitesmoke;
-  color: #ff1245;
-  font-size: 0.8em;
   font-weight: normal;
   padding: 0.25em 0.5em 0.25em;
 }
@@ -3160,9 +3157,7 @@ input[type="submit"].button {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
-  background-color: whitesmoke;
   border-radius: 290486px;
-  color: #4a4a4a;
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -3172,8 +3167,6 @@ input[type="submit"].button {
       -ms-flex-pack: center;
           justify-content: center;
   line-height: 1.5;
-  padding-left: 0.875em;
-  padding-right: 0.875em;
   white-space: nowrap;
 }
 

--- a/themes/cucumber-hugo/static/css/prism.css
+++ b/themes/cucumber-hugo/static/css/prism.css
@@ -64,7 +64,6 @@ pre[class*="language-"] {
 }
 
 .token.property,
-.token.tag,
 .token.constant,
 .token.symbol,
 .token.deleted {


### PR DESCRIPTION
Update css to fix bug in Ruby examples; see #49
For some reason `#{` and `}` in the Ruby code examples were shown inside a white circle and with different text color and alignment.
This should fix it.

I've tested by starting the site locally and manually verifying 1. that the bug was fixed and 2. checking several other pages with & without Ruby examples. (Note: I did not check all pages)