### PR TITLE
Update jvm group id, versions, options and add JUnit annotations

### DIFF
--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -189,7 +189,7 @@ java cucumber.api.cli.Main --version
 The [JUnit Runner](#junit-runner) and [Android Runner](#android-runner) can also pick
 up configuration options defined via the `@CucumberOptions` annotation.
 
-**Note:** Cucumber only supports @ClassRule},@BeforeClass and @AfterClass JUnit annotations.
+**Note:** Cucumber only supports @ClassRule,@BeforeClass and @AfterClass JUnit annotations.
 
 For example, if you want to tell Cucumber to use the two formatter plugins `pretty` and `html`, you can specify it like this:
 

--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -30,17 +30,18 @@ Other JVM languages have been moved to their own repository:
 
 ## Installation
 
-Cucumber-JVM consists of several modules (JARs) that you can download from the [public Maven repo](http://repo1.maven.org/maven2/io/cucumber/).
-There is no "setup" program for Cucumber-JVM---just JAR files.
+Cucumber-JVM consists of several modules (JARs). We recommend using a build tool, like [Maven](https://maven.apache.org/) or [Gradle](https://gradle.org/),
+to manage the dependencies in your project.
 
-Determining which JARs to add to your project's `CLASSPATH` depends on the programming language you are using. If you
-are using Java, you may want to add one of the JARs for [dependency injection](/implementations/jvm/java-di/) as well.
+Determining which dependencies to add to your project, depends on the programming language you are using. If you
+are using Java, you may also want to add one of the JARs for [dependency injection](/implementations/jvm/java-di/).
+In addition, you may want to use a test framework, like JUnit or TestNg.
 
 ### Snapshot releases
 
 If you want to take advantage of functionality that has been committed to the git `master` branch, but hasn't been released to the public maven repo yet, you can use `SNAPSHOT` builds from the [sonatype snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/io/cucumber/).
 
-Just add the following to your `pom.xml`:
+If you are using Maven, just add the following to your `pom.xml`:
 
 ```xml
 <repository>
@@ -66,6 +67,8 @@ For example:
 ```
 
 You can find the current snapshot version number [here](https://github.com/cucumber/cucumber-jvm/blob/master/pom.xml).
+
+If you are using Gradle, check the [build.gradle](https://github.com/cucumber/cucumber-java-skeleton/blob/master/build.gradle) file in the cucumber-java-skeleton project.
 
 ## Running Cucumber
 
@@ -100,9 +103,9 @@ To use the JUnit runner you need to add the following dependencies:
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-junit</artifactId>
-    <version>2.1.0</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 
@@ -116,11 +119,11 @@ To use the JUnit runner you need to add the following dependencies:
 
 ### Maven Runner
 
-To run Cucumber with Maven, make sure that
+To run Cucumber with [Maven](https://maven.apache.org/), make sure that
 
 - Maven is installed
 - The environment variable `MAVEN_HOME` is correctly configured
-- Your IDE is configured with latest maven installation
+- Your IDE is configured with latest Maven installation
 
 Steps:
 
@@ -131,7 +134,7 @@ Steps:
     <dependency>
         <groupId>io.cucumber</groupId>
       	<artifactId>cucumber-java</artifactId>
-      	<version>2.1.0</version>
+      	<version>{{ site.versions.cucumber_jvm }}</version>
     </dependency>
     ```
 
@@ -189,7 +192,7 @@ java cucumber.api.cli.Main --version
 The [JUnit Runner](#junit-runner) and [Android Runner](#android-runner) can also pick
 up configuration options defined via the `@CucumberOptions` annotation.
 
-**Note:** Cucumber only supports @ClassRule,@BeforeClass and @AfterClass JUnit annotations.
+**Note:** Cucumber only supports `@ClassRule`,`@BeforeClass` and `@AfterClass` JUnit annotations.
 
 For example, if you want to tell Cucumber to use the two formatter plugins `pretty` and `html`, you can specify it like this:
 
@@ -282,24 +285,24 @@ Some of the runners provide additional mechanisms for passing options to Cucumbe
 ### {java-}Dependency
 
 If you are going to use the lambda expressions API to write the Step
-Definitions, you need:
+Definitions, you need to add the following dependency to your  `pom.xml`:
 
 ```xml
 <dependency>
     <groupId>io.cucumber</groupId>
-    <artifactId>cucumber-java</artifactId>
-    <version>2.1.0</version>
+    <artifactId>cucumber-java8</artifactId>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
 
-Otherwise, to write them using annotated methods, you need:
+Otherwise, to write them using annotated methods, you need to add the following dependency to your  `pom.xml`:
 
 ```xml
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-java</artifactId>
-    <version>2.1.0</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -397,7 +400,7 @@ Definition.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-groovy</artifactId>
-    <version>${version}</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -410,7 +413,7 @@ Definition.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-scala</artifactId>
-    <version>${version}</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -423,7 +426,7 @@ Definition.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-clojure</artifactId>
-    <version>${version}</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -436,7 +439,7 @@ Definition.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-jython</artifactId>
-    <version>${version}</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -449,7 +452,7 @@ Definition.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-jruby</artifactId>
-    <version>${version}</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -462,7 +465,7 @@ Definition.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-rhino</artifactId>
-    <version>${version}</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -475,7 +478,7 @@ Definition.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-gosu</artifactId>
-    <version>${version}</version>
+    <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/content/implementations/jvm.md
+++ b/content/implementations/jvm.md
@@ -19,26 +19,26 @@ Please see the [General Reference](/gherkin/gherkin-reference/) for functionalit
 Cucumber-JVM supports Java, Kotlin and Android.
 
 Other JVM languages have been moved to their own repository:
-* [Clojure](https://github.com/cucumber/cucumber-jvm-clojure)
-* [Gosu](https://github.com/cucumber/cucumber-jvm-gosu)
-* [Groovy](https://github.com/cucumber/cucumber-jvm-groovy)
-* [JRuby](https://github.com/cucumber/cucumber-jvm-jruby)
-* [Jython](https://github.com/cucumber/cucumber-jvm-jython)
-* [Rhino](https://github.com/cucumber/cucumber-jvm-rhino)
-* [Scala](https://github.com/cucumber/cucumber-jvm-scala)
+- [Clojure](https://github.com/cucumber/cucumber-jvm-clojure)
+- [Gosu](https://github.com/cucumber/cucumber-jvm-gosu)
+- [Groovy](https://github.com/cucumber/cucumber-jvm-groovy)
+- [JRuby](https://github.com/cucumber/cucumber-jvm-jruby)
+- [Jython](https://github.com/cucumber/cucumber-jvm-jython)
+- [Rhino](https://github.com/cucumber/cucumber-jvm-rhino)
+- [Scala](https://github.com/cucumber/cucumber-jvm-scala)
 
 
 ## Installation
 
-Cucumber-JVM consists of several modules (JARs) that you can download from the [public Maven repo](http://repo1.maven.org/maven2/info/cukes/).
+Cucumber-JVM consists of several modules (JARs) that you can download from the [public Maven repo](http://repo1.maven.org/maven2/io/cucumber/).
 There is no "setup" program for Cucumber-JVM---just JAR files.
 
-Determining which JARs to add to your project's `CLASSPAth` depends on the programming language you are using. If you
+Determining which JARs to add to your project's `CLASSPATH` depends on the programming language you are using. If you
 are using Java, you may want to add one of the JARs for [dependency injection](/implementations/jvm/java-di/) as well.
 
 ### Snapshot releases
 
-If you want to take advantage of functionality that has been committed to the git `master` branch, but hasn't been released to the public maven repo yet, you can use `SNAPSHOT` builds from the [sonatype snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/info/cukes/).
+If you want to take advantage of functionality that has been committed to the git `master` branch, but hasn't been released to the public maven repo yet, you can use `SNAPSHOT` builds from the [sonatype snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/io/cucumber/).
 
 Just add the following to your `pom.xml`:
 
@@ -58,9 +58,9 @@ For example:
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-java</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -102,7 +102,7 @@ To use the JUnit runner you need to add the following dependencies:
 <dependency>
     <groupId>info.cukes</groupId>
     <artifactId>cucumber-junit</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>2.1.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -118,22 +118,22 @@ To use the JUnit runner you need to add the following dependencies:
 
 To run Cucumber with Maven, make sure that
 
-* Maven is installed
-* The environment variable `MAVEN_HOME` is correctly configured
-* Your IDE is configured with latest maven installation
+- Maven is installed
+- The environment variable `MAVEN_HOME` is correctly configured
+- Your IDE is configured with latest maven installation
 
 Steps:
 
 1.  Create a new Maven project or fork from cucumber-java examples on github
 2.  Add the following dependency to your  `pom.xml`
 
-      ```xml
-      <dependency>
-      	<groupId>io.cucumber</groupId>
+    ```xml
+    <dependency>
+        <groupId>io.cucumber</groupId>
       	<artifactId>cucumber-java</artifactId>
-      	<version>2.0.1</version>
-      </dependency>
-      ```
+      	<version>2.1.0</version>
+    </dependency>
+    ```
 
 3.  Add your feature `.feature` files and associated step mapping classes `.java` in `src/test/resources` and `src/test/java` folders respectively.
 4.  Run the following maven from the directory path where your `pom.xml` file is located:
@@ -189,6 +189,8 @@ java cucumber.api.cli.Main --version
 The [JUnit Runner](#junit-runner) and [Android Runner](#android-runner) can also pick
 up configuration options defined via the `@CucumberOptions` annotation.
 
+**Note:** Cucumber only supports @ClassRule},@BeforeClass and @AfterClass JUnit annotations.
+
 For example, if you want to tell Cucumber to use the two formatter plugins `pretty` and `html`, you can specify it like this:
 
 ```java
@@ -232,13 +234,16 @@ Options:
 
   -g, --glue PATH                        Where glue code (step definitions, hooks
                                          and plugins) are loaded from.
-  -p, --plugin PLUGIN[:PATH_OR_URL]      Register a plugin.
+  -p, --[add-]plugin PLUGIN[:PATH_OR_URL]
+                                         Register a plugin.
                                          Built-in formatter PLUGIN types: junit,
                                          html, pretty, progress, json, usage, rerun,
                                          testng. Built-in summary PLUGIN types:
                                          default_summary, null_summary. PLUGIN can
                                          also be a fully qualified class name, allowing
                                          registration of 3rd party plugins.
+                                         --add-plugin does not clobber plugins of that
+                                         type defined from a different source.
   -f, --format FORMAT[:PATH_OR_URL]      Deprecated. Use --plugin instead.
   -t, --tags TAG_EXPRESSION              Only run scenarios tagged with tags matching
                                          TAG_EXPRESSION.
@@ -252,6 +257,9 @@ Options:
   -h, --help                             You're looking at it.
   --i18n LANG                            List keywords for in a particular language
                                          Run with "--i18n help" to see all languages
+  --junit,OPTION[,OPTION]*               Pass the OPTION(s) to the JUnit module.
+                                         Use --junit,-h or --junit,--help to print the
+                                         options of the JUnit module.
 
 Feature path examples:
   <path>                                 Load the files with the extension ".feature"
@@ -278,9 +286,9 @@ Definitions, you need:
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
-    <artifactId>cucumber-java8</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <groupId>io.cucumber</groupId>
+    <artifactId>cucumber-java</artifactId>
+    <version>2.1.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -289,9 +297,9 @@ Otherwise, to write them using annotated methods, you need:
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-java</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>2.1.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -387,9 +395,9 @@ Definition.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-groovy</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>${version}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -400,9 +408,9 @@ Definition.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-scala</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>${version}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -413,9 +421,9 @@ Definition.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-clojure</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>${version}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -426,9 +434,9 @@ Definition.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-jython</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>${version}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -439,9 +447,9 @@ Definition.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-jruby</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>${version}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -452,9 +460,9 @@ Definition.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-rhino</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>${version}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -465,9 +473,9 @@ Definition.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-gosu</artifactId>
-    <version>{{ site.versions.cucumber_jvm }}</version>
+    <version>${version}</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
Update group id from info.cukes to io.cucumber
Update to latest jvm version and snapshot version
Update command line options
Add supported JUnit annationations (related to https://github.com/cucumber/cucumber-jvm/issues/1268)