### PR TITLE
Fixes #64 Updates maven group id

### DIFF
--- a/content/implementations/jvm/java-di.md
+++ b/content/implementations/jvm/java-di.md
@@ -27,7 +27,7 @@ The available Dependency Injection modules are:
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-picocontainer</artifactId>
     <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
@@ -43,7 +43,7 @@ For more information, please see [sharing state using Picocontainer](http://www.
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-spring</artifactId>
     <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
@@ -59,7 +59,7 @@ For more information, please see [sharing state using Spring](http://www.thinkco
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-guice</artifactId>
     <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>

--- a/content/implementations/jvm/java-di.md
+++ b/content/implementations/jvm/java-di.md
@@ -74,7 +74,7 @@ For more information, please see [sharing state using Guice](http://www.thinkcod
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-openejb</artifactId>
     <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
@@ -89,7 +89,7 @@ There is no documentation yet, but the code is on [GitHub](https://github.com/cu
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-weld</artifactId>
     <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>
@@ -104,7 +104,7 @@ There is no documentation yet, but the code is on [GitHub](https://github.com/cu
 
 ```xml
 <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-needle</artifactId>
     <version>{{ site.versions.cucumber_jvm }}</version>
     <scope>test</scope>

--- a/content/tutorial/getting-started-with-cucumber-jvm-in-five-minutes.md
+++ b/content/tutorial/getting-started-with-cucumber-jvm-in-five-minutes.md
@@ -145,7 +145,7 @@ We'll have to add a dependency for Cucumber core, as follows:
 
 ```
  <dependency>
-    <groupId>info.cukes</groupId>
+    <groupId>io.cucumber</groupId>
     <artifactId>cucumber-core</artifactId>
     <version>${cucumber.version}</version>
     <scope>test</scope>


### PR DESCRIPTION
Didn't update group for `cucumber-weld`, `cucumber-needle` and `cucumber-openejb` as they don't exist under `io.cucumber`