### PR TITLE
Fix menu link to step-definitions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,7 +37,7 @@ pygmentsUseClasses = true
     weight = 7
     name = "Step Definitions"
     identifier = "Connecting Gherkin to code"
-    url = "/hooks/"
+    url = "/step-definitions/"
 [[menu.documentation]]
     weight = 8
     name = "Hooks"


### PR DESCRIPTION
Menu link Step Definitions linked to 'hooks' document.
This fixes the link