### PR TITLE
Fix GitHub logo on landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 /.idea/
 node_modules/
 .DS_Store
+*.iml

--- a/content/_index.html
+++ b/content/_index.html
@@ -34,12 +34,16 @@
   <div class="hero-body">
     <div class="container">
       <nav class="columns">
-        <a class="column has-text-centered" href="https://github.com/cucumber/cucumber">
+        <div class="column has-text-centered">
+          <a href="https://github.com/cucumber/cucumber" target="_blank">
           <span class="icon is-large">
             <i class="fa fa-3x fa-github"></i>
           </span>
-          <p class="subtitle">Open source on <strong>GitHub</strong></p>
-        </a>
+          </a>
+          <p class="subtitle">
+            Open source on <strong>GitHub</strong>
+          </p>
+        </div>
         <div class="column has-text-centered">
           <a href="https://opencollective.com/cucumber/donate" target="_blank">
             <img src="https://opencollective.com/cucumber/donate/button@2x.png?color=white" width="300" alt="OpenCollective Logo"/>


### PR DESCRIPTION
This fixes the alignment of the GitHub logo (partial fix for #121).
Still trying to figure out how to fix the Cucumber logo...