### PR TITLE
update stepdefs file extention for Ruby

### DIFF
--- a/content/10-minute-tutorial.md
+++ b/content/10-minute-tutorial.md
@@ -457,7 +457,7 @@ end
 Copy each of the three snippets for the undefined steps and paste them into
 {{% text "java" %}}`src/test/java/hellocucumber/Stepdefs.java`{{% /text %}}
 {{% text "javascript" %}}`features/step_definitions/stepdefs.js`{{% /text %}}
-{{% text "ruby" %}}`features/step_definitions/stepdefs.js`{{% /text %}}.
+{{% text "ruby" %}}`features/step_definitions/stepdefs.rb`{{% /text %}}.
 
 # See scenario reported as pending
 


### PR DESCRIPTION
In Ruby stepdefs file extention should be .rb not .js