### PR TITLE
[WIP] Fixed highlighting in Tag expresssions example

### DIFF
--- a/themes/cucumber-hugo/static/css/pygments.sass
+++ b/themes/cucumber-hugo/static/css/pygments.sass
@@ -9,7 +9,7 @@
       display: inline-block
       width: 100%
 
-      .n, .o
+      .n
         color: $black
 
       .c, .cm, .c1


### PR DESCRIPTION
For some reason,  using fenced code blocks with the language set to `shell` results in special characters (notably, `(`, `)` and `=`) becoming `span` elements with the `o` class. This results in the special characters being rendered black (`#1b1d1e`).

See the following snippet for an example of how the HTML is rendered:
```html
<div class="highlight">
  <pre class="chroma">
    <code class="language-shell" data-lang="shell">
      <span class="o">(</span>
      @smoke or @ui
      <span class="o">)</span> 
      and 
      <span class="o">(</span>
      not @slow
      <span class="o">)</span>
    </code>
  </pre>
</div>
```
To see the issue in action, navigate to https://docs.cucumber.io/cucumber/api/#tag-expressions. Or see the following images:
![screenshot from 2018-04-30 18-23-06](https://user-images.githubusercontent.com/9316813/39419507-97779a22-4ca3-11e8-9957-b20132befa17.png)
![screenshot from 2018-04-30 18-23-21](https://user-images.githubusercontent.com/9316813/39419509-9c09bd4a-4ca3-11e8-922f-d8e6622b0d1b.png)


I've simply removed `.highlight pre code .o` from the `pygments.sass` file. I'm not sure what else this breaks - and I haven't yet tested this. This is more of a WIP than anything.

This PR is an attempt to resolve Issue https://github.com/cucumber/docs.cucumber.io/issues/162.