### PR TITLE
Contribute docs (Fixes 

### DIFF
--- a/content/community/contributing-to-documentation.md
+++ b/content/community/contributing-to-documentation.md
@@ -165,19 +165,18 @@ Wrap `{{%/* block %}}` shortcodes around paragraphs and fenced code blocks:
     ```
     {{% /block */%}}
 
-Please note that you cannot use headers inside language blocks. If you are writing a page with content for a specific language, perhaps it should be a separate page.
+Please note that you cannot use headers *inside* language blocks. If you are writing a page with content for a specific language,
+perhaps it should be a separate page. Or use a header per language.
 
 ## Language-specific text fragments
 
 Use the `{{%/* text */%}}` shortcode around text fragments that should only be displayed for
 a particular programming language:
 
-
     The preferred build tool is
     {{%/* text "ruby" %}}Rake{{% /text %}}
     {{% text "javascript" %}}Yarn{{% /text %}}
     {{% text "java" %}}Maven{{% /text */%}}.
-
 
 ## Working locally
 

--- a/content/community/contributing-to-documentation.md
+++ b/content/community/contributing-to-documentation.md
@@ -5,7 +5,7 @@ subtitle: Help us make these docs better
 
 The Cucumber documentation is open source and anyone is welcome to contribute.
 
-Please make ALL contributions to the documentation in [docs.cucumber.io](https://github.com/cucumber/docs.cucumber.io).
+Each page provides a link to easily edit the content of that page. You can also make your changes to the [docs.cucumber.io](https://github.com/cucumber/docs.cucumber.io) project.
 
 # Process
 
@@ -26,9 +26,9 @@ The more general contribution process is described in the [Cucumber Community Co
 
 It's great to get feedback on your writing. Start out with small changes, then wait for feedback from other contributors and committers in the pull request.
 
-You can hop into the Cucumber [Slack](https://cucumber.io/support#slack) channel `#committers-docs` or [Gitter](https://cucumber.io/support#gitter) chat rooms to discuss.
+You can hop into the Cucumber [Slack](https://cucumber.io/support#slack) channel `#docs` or [Gitter](https://cucumber.io/support#gitter) chat rooms to discuss.
 
-Otherwise - there is always the friendly [Cucumber Google group](mailto:cukes-devs@googlegroups.com)
+Otherwise - there is always the friendly [Cucumber Google group](mailto:cukes-devs@googlegroups.com).
 
 # What to contribute
 A great way to start contributing is to answer a
@@ -53,8 +53,8 @@ In general, it should be brief and to the point.
 ## General writing style
 
 * Every page should start with an informational/motivational paragraph
-* Paragraphs should be short enough to be readable, but long enough to develop an idea.
-* Every page should start with a `h1` heading. Sections use `h2`. Subsections use `h3`.
+* Paragraphs should be short enough to be readable, but long enough to develop an idea
+* Every page should start with a `h1` heading. Sections use `h2`. Subsections use `h3`
 * Break long lines. Insert a new line at around column 80. This is important because review comments can only be added to a line.
 * Write in present tense
 * Use unemotional language, but try to make it a little entertaining (this is hard!)
@@ -64,16 +64,16 @@ In general, it should be brief and to the point.
 * Use [code blocks](#language-specific-source-code-and-paragraphs) for all code examples (except Gherkin)
   * If you're only familiar with one programming language - just add an example for that language - someone
     else will fill the gaps for the other languages!
-  * You can ask for help with the other languages in the help channel for that Slack, or in your GitHub pull request / issue.
+  * You can ask for help with the other languages in the help channel for that Slack, or in your GitHub pull request / issue
 * Use [language blocks](#Language-specific-text-fragments) for text that is only relevant for (a) specific language(s)
   * If you're only familiar with one programming language - just add text for that language - someone
     else will fill the gaps for the other languages!
-  * You can ask for help with the other languages in the help channel for that Slack, or in your GitHub pull request / issue.
+  * You can ask for help with the other languages in the help channel for that Slack, or in your GitHub pull request / issue
 * All documents should use [British English](https://en.wikipedia.org/wiki/British_English)
   * Contributions in [American English](https://en.wikipedia.org/wiki/American_English) is fine - editors will do the translation.
 * Use links to external sites sparingly
 * Do not use copyrighted material (images, text or other)
-* Illustrations are great, but please use lo-fi drawings. Cucumber's design team will recreate illustrations according to Cucumber's [brand guidelines](https://github.com/cucumber-ltd/brand).
+* Illustrations are great, but please use lo-fi drawings; Cucumber's design team will recreate illustrations according to Cucumber's [brand guidelines](https://github.com/cucumber-ltd/brand)
 
 ## Tutorial writing style {#tutorial-style}
 
@@ -116,22 +116,31 @@ look good.
 Pages can contain variations of the same content that conditionally displays
 text or source code for a particular programming language.
 
-A language select will be displayed if the page specifies `polyglot:
+A language select will be displayed if the page specifies the following in the front-matter:
+
+ ```
+ polyglot:
  - java
  - javascript
  - ruby
-`
-in the front-matter.
+ - dotnet
+ ```
 
 The following languages are currently supported:
 
 * Java
 * JavaScript
 * Ruby
+* .Net (optional; some pages only)
+
+* If possible, we'd prefer for you to add information for Java, JavaScript and Ruby.
+  * If you're only familiar with one programming language - just add text for that language - someone
+    else will fill the gaps for the other languages!
+  * You can ask for help with the other languages in the help channel for that Slack, or in your GitHub pull request / issue
 
 ## Language-specific source code and paragraphs
 
-Wrap `{{% block %}}` shortcodes around paragraphs and fenced code blocks:
+Wrap `{{% block ``%}}` shortcodes around paragraphs and fenced code blocks:
 
     {{% block "ruby" %}}
     Put this in your `hello.rb`:
@@ -155,6 +164,8 @@ Wrap `{{% block %}}` shortcodes around paragraphs and fenced code blocks:
     System.out.println("hello")
     ```
     {{% /block %}}
+
+Please note that you cannot use headers inside language blocks. If you are writing a page with content for a specific language, perhaps it should be a separate page.
 
 ## Language-specific text fragments
 

--- a/content/community/contributing-to-documentation.md
+++ b/content/community/contributing-to-documentation.md
@@ -140,7 +140,7 @@ The following languages are currently supported:
 
 ## Language-specific source code and paragraphs
 
-Wrap `{{%/* block */%}}` shortcodes around paragraphs and fenced code blocks:
+Wrap `{{%/* block %}}` shortcodes around paragraphs and fenced code blocks:
 
     {{% block "ruby" %}}
     Put this in your `hello.rb`:
@@ -148,22 +148,22 @@ Wrap `{{%/* block */%}}` shortcodes around paragraphs and fenced code blocks:
     ```ruby
     puts "hello"
     ```
-    {{% /block %}}
+    {{% /block */%}}
 
-    {{% block "javascript" %}}
+    {{%/* block "javascript" %}}
     Put this in your `hello.js`:
 
     ```javascript
     console.log("hello")
     ```
-    {{% /block %}}
+    {{% /block */%}}
 
-    {{% block "java" %}}
+    {{%/* block "java" %}}
     Put this in your `Hello.java`:
     ```java
     System.out.println("hello")
     ```
-    {{% /block %}}
+    {{% /block */%}}
 
 Please note that you cannot use headers inside language blocks. If you are writing a page with content for a specific language, perhaps it should be a separate page.
 
@@ -174,9 +174,9 @@ a particular programming language:
 
 
     The preferred build tool is
-    {{% text "ruby" %}}Rake{{% /text %}}
+    {{%/* text "ruby" %}}Rake{{% /text %}}
     {{% text "javascript" %}}Yarn{{% /text %}}
-    {{% text "java" %}}Maven{{% /text %}}.
+    {{% text "java" %}}Maven{{% /text */%}}.
 
 
 ## Working locally

--- a/content/community/contributing-to-documentation.md
+++ b/content/community/contributing-to-documentation.md
@@ -140,7 +140,7 @@ The following languages are currently supported:
 
 ## Language-specific source code and paragraphs
 
-Wrap `{{% block ``%}}` shortcodes around paragraphs and fenced code blocks:
+Wrap `{{%/* block */%}}` shortcodes around paragraphs and fenced code blocks:
 
     {{% block "ruby" %}}
     Put this in your `hello.rb`:
@@ -169,13 +169,15 @@ Please note that you cannot use headers inside language blocks. If you are writi
 
 ## Language-specific text fragments
 
-Use the `{{% text %}}` shortcode around text fragments that should only be displayed for
+Use the `{{%/* text */%}}` shortcode around text fragments that should only be displayed for
 a particular programming language:
+
 
     The preferred build tool is
     {{% text "ruby" %}}Rake{{% /text %}}
     {{% text "javascript" %}}Yarn{{% /text %}}
     {{% text "java" %}}Maven{{% /text %}}.
+
 
 ## Working locally
 


### PR DESCRIPTION
Made a little progress on #200 with help of this example:
https://matcornic.github.io/hugo-learn-doc/cont/shortcodes/
https://github.com/matcornic/hugo-learn-doc/edit/master/content/cont/shortcodes/index.md

`{{% block %}}` and `{{% text %}}` are now rendered correctly. 
Also the complete page is shown 
(rather than ending at:
 `**Language-specific source code and paragraphs**

Wrap \`
)

However, the examples per language for blocks, source code and text took a little more time to figure out exactly where to put the escape characters `/*` and  `*/` so they would correctly escape (i.e. without showing up on the page). 

Also edited content a little bit.

