### PR TITLE
Fix 'Parameter Type' ruby example

### DIFF
--- a/content/cucumber/configuration.md
+++ b/content/cucumber/configuration.md
@@ -62,7 +62,7 @@ For example, let's define our own "Person" type:
 
 ```ruby
 ParameterType(
-  name: 'person'
+  name: 'person',
   regexp: /[A-Z][a-z]+/,
   transformer: -> (name) { Person.new(name) }
 end


### PR DESCRIPTION
If I just copy-paste the example I would end up with syntax error.