### PR TITLE
Update browser-automation.md

### DIFF
--- a/content/guides/browser-automation.md
+++ b/content/guides/browser-automation.md
@@ -44,7 +44,7 @@ import cucumber.api.java.en.When;
 public class ExampleSteps {
 
     private final WebDriver driver = new FirefoxDriver();
-    @Given("^I am on the Google search page$"\)
+    @Given("^I am on the Google search page$")
     public void I_visit_google() {
     driver.get("https:\\www.google.com");
    }

--- a/content/guides/browser-automation.md
+++ b/content/guides/browser-automation.md
@@ -59,7 +59,7 @@ public class ExampleSteps {
    }
 
    @Then("^ the page title should start with \"(.*)\"$")
-   public void checkTitle() {
+   public void checkTitle(String titleStartsWith) {
        // Google's search is rendered dynamically with JavaScript
        // Wait for the page to load timeout after ten seconds
        new WebDriverWait(driver,'10').until(new ExpectedCondition<Boolean>() {

--- a/content/guides/browser-automation.md
+++ b/content/guides/browser-automation.md
@@ -62,7 +62,7 @@ public class ExampleSteps {
    public void checkTitle(String titleStartsWith) {
        // Google's search is rendered dynamically with JavaScript
        // Wait for the page to load timeout after ten seconds
-       new WebDriverWait(driver,'10').until(new ExpectedCondition<Boolean>() {
+       new WebDriverWait(driver,10L).until(new ExpectedCondition<Boolean>() {
            public Boolean apply(WebDriver d) {
                return d.getTitle().toLowerCase().startsWith("cheese");
                // Should see: "cheese! -Google Search"


### PR DESCRIPTION
test in the example does not pass with an exception:
cucumber.runtime.CucumberException: Arity mismatch: Step Definition 'geoorg.Stepdefs.checkTitle() in file:.../cucumber-selenium-java8/target/test-classes/' with pattern [^the page title should start with "(.*)"$] is declared with 0 parameters. However, the gherkin step has 1 arguments [cheese].