### PR TITLE
Convert the Debugging article from the wiki

### DIFF
--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -135,23 +135,25 @@ By setting an environment variable, you can tell Cucumber to use various debuggi
 {{% block "java" %}}
 In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. The example below uses IntelliJ, but Eclipse will have similar functionality.
 
-1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [Breakpoints](https://www.jetbrains.com/help/idea/breakpoints.html) for more details on how to set one on IDEA):
+1. Set a conditional breakpoint on th epart of the code you want to debug. 
+This might be the line you are currently getting an Exception (see your stacktrace). 
+Or, if you don't know where to start, you can set a breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 26 in `cucumber-jvm` master at the time of writing) and specify the following snippet as the condition: 
+```java
+Package pkg = target.getClass().getPackage();
+  if (pkg == null) {
+    return false;
+  }
+  return !target.getClass().getPackage().getName().startsWith("cucumber");
+```
+For more details on how to set a breakpoint in your IDE, see:
+* [Breakpoints - IntelliJ](https://www.jetbrains.com/help/idea/breakpoints.html)
+* [Debugging - Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
 
-        Package pkg = target.getClass().getPackage();
-        if (pkg == null) {
-            return false;
-        }
-        return !target.getClass().getPackage().getName().startsWith("cucumber");
- 
 2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode
 3. Assuming you haven't set any other breakpoints, the execution will stop at `Utils#invoke`
 4. Now you can either:
    - *Step into* to start debugging the method implementing the first step of the scenario
    - Or *Resume* the execution to run the current step and jump to the next one
 5. And so on..
-{{% /block %}}
-
-{{% block "javascript" %}}
-TBD.
 {{% /block %}}
 

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -156,4 +156,3 @@ For more details on how to set a breakpoint in your IDE, see:
    - Or *Resume* the execution to run the current step and jump to the next one
 5. And so on..
 {{% /block %}}
-

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -144,10 +144,6 @@ Package pkg = target.getClass().getPackage();
   }
   return !target.getClass().getPackage().getName().startsWith("cucumber");
 ```
-
-For more details on how to set a breakpoint in your IDE, see:
-   - [Breakpoints (IntelliJ)](https://www.jetbrains.com/help/idea/breakpoints.html)
-   - [Debugging (Eclipse)](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
    
 2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode
 3. Assuming you haven't set any other breakpoints, the execution will stop at `Utils#invoke`
@@ -155,4 +151,8 @@ For more details on how to set a breakpoint in your IDE, see:
    - *Step into* to start debugging the method implementing the first step of the scenario
    - Or *Resume* the execution to run the current step and jump to the next one
 5. And so on..
+
+For more details on how to set a breakpoint in your IDE, see:
+   - [Breakpoints (IntelliJ)](https://www.jetbrains.com/help/idea/breakpoints.html)
+   - [Debugging (Eclipse)](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
 {{% /block %}}

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -145,8 +145,8 @@ Package pkg = target.getClass().getPackage();
   return !target.getClass().getPackage().getName().startsWith("cucumber");
 ```
 For more details on how to set a breakpoint in your IDE, see:
-- [Breakpoints - IntelliJ](https://www.jetbrains.com/help/idea/breakpoints.html)
-- [Debugging - Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
+   - [Breakpoints - IntelliJ](https://www.jetbrains.com/help/idea/breakpoints.html)
+   - [Debugging - Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
 2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode
 3. Assuming you haven't set any other breakpoints, the execution will stop at `Utils#invoke`
 4. Now you can either:

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -1,0 +1,155 @@
+---
+title: Debugging
+subtitle: How to debug failing Cucumber steps
+polyglot:
+ - java
+ - ruby
+
+---
+
+
+# Debugging failing Cucumber steps
+
+{{% block "ruby" %}}
+(The code given below calls on [the logging facilities of Ruby on Rails](https://guides.rubyonrails.org/debugging_rails_applications.html#the-logger). If you're not using Rails, replace those calls with `puts` or `warn`.)
+
+Adding the following as the contents of `features/support/debugging.rb` can be helpful in debugging failing steps:
+
+```ruby
+# rubocop:disable Lint/Debugger
+class CucumberCounters
+  @error_counter = 0
+  @step_counter = 0
+  @screenshot_counter = 0
+  class << self
+    attr_accessor :error_counter, :step_counter, :screenshot_counter
+  end
+end
+
+# `LAUNCHY=1 cucumber` to open save screenshot after every step
+After do |scenario|
+  next unless (ENV['LAUNCHY'] || ENV['CI']) && scenario.failed?
+  puts "Opening snapshot for #{scenario.name}"
+  begin
+    save_and_open_screenshot
+  rescue StandardError
+    puts "Can't save screenshot"
+  end
+  begin
+    save_and_open_page
+  rescue StandardError
+    puts "Can't save page"
+  end
+end
+
+# `FAST=1 cucumber` to stop on first failure
+After do |scenario|
+  Cucumber.wants_to_quit = ENV['FAST'] && scenario.failed?
+end
+
+# `DEBUG=1 cucumber` to drop into debugger on failure
+Cucumber::Core::Test::Action.class_eval do
+  ## first make sure we don't lose original accept method
+  unless instance_methods.include?(:orig_failed)
+    alias_method :orig_failed, :failed
+  end
+
+  ## wrap original accept method to catch errors in executed step
+  def failed(*args)
+    begin
+      CucumberCounters.error_counter += 1
+      file_name = format('tmp/capybara/error_%03d.png',
+                         CucumberCounters.error_counter)
+      Capybara.page.save_screenshot(file_name, full: true)
+    rescue
+      Rails.logger.info('[Cucumber] Can not make screenshot of failure')
+    end
+    binding.pry if ENV['DEBUG']
+    orig_failed(*args)
+  end
+end
+
+# `STEP=1 cucumber` to pause after each step
+AfterStep do |scenario|
+  next unless ENV['STEP']
+  unless defined?(@counter)
+    puts "Stepping through #{@scenario_name}"
+    @counter = 0
+  end
+  @counter += 1
+  print "After step ##{@counter}/#{scenario.send(:steps).try(:count)}: "\
+        "#{scenario.send(:steps).to_a[@counter].try(:name) ||
+        '[RETURN to continue]'}..."
+  STDIN.getc
+end
+
+Before do |scenario|
+  case scenario
+  when Cucumber::Ast::Scenario
+    @scenario_name = scenario.name
+  when Cucumber::Ast::OutlineTable::ExampleRow
+    @scenario_name = scenario.scenario_outline.name
+  end
+  Rails.logger.info("[Cucumber] starting the #{@scenario_name}")
+end
+
+AfterStep do |scenario|
+  CucumberCounters.step_counter += 1
+  step = CucumberCounters.step_counter
+  file_name = format('tmp/capybara/step_%03d.png', step)
+  Rails.logger.info("[Cucumber] after step: #{@scenario_name}, step: #{step}")
+  next unless scenario.source_tag_names.include? '@intermittent'
+  begin
+    Capybara.page.save_screenshot(file_name, full: true)
+    Rails.logger.info("[Cucumber] Screenshot #{step} saved")
+  rescue
+    Rails.logger.info("[Cucumber] Can not make screenshot of #{step}")
+  end
+end
+
+# rubocop:disable Lint/HandleExceptions
+AfterStep do
+  begin
+    execute_script "$(window).unbind('beforeunload')"
+  rescue
+  end
+end
+# rubocop:enable Lint/HandleExceptions
+
+def dismiss_nav_warning
+  execute_script "$(window).unbind('beforeunload')"
+  loop_until_jquery_inactive
+end
+
+def loop_until_jquery_inactive
+  Timeout.timeout(Capybara.default_max_wait_time) do
+    loop until page.evaluate_script('jQuery.active').zero?
+  end
+end
+```
+By setting an environment variable, you can cause Cucumber to use various debugging tools, and you can combine them by setting multiple environment variables.
+{{% /block %}}
+
+{{% block "java" %}}
+Here is how to debug your scenarios on the JVM, by stepping through the steps of each scenario:
+
+1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html](https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html) for more details on how to set one on IDEA):
+
+        Package pkg = target.getClass().getPackage();
+        if (pkg == null) {
+            return false;
+        }
+        return !target.getClass().getPackage().getName().startsWith("cucumber");
+ 
+2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode
+3. Assuming you haven't set any other breakpoints, the execution will stop at `Utils#invoke`
+4. Now you can either:
+   - _Step into_ to start debugging the method implementing the first step of the scenario
+   - Or _Resume_ the execution to run the current step and jump to the next one
+5. And so on..
+{{% /block %}}
+
+{{% block "javascript" %}}
+TBD.
+{{% /block %}}
+

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -135,7 +135,7 @@ By setting an environment variable, you can tell Cucumber to use various debuggi
 {{% block "java" %}}
 In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. The example below uses IntelliJ, but Eclipse will have similar functionality.
 
-1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [Breakpoints](https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html) for more details on how to set one on IDEA):
+1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [Breakpoints](https://www.jetbrains.com/help/idea/breakpoints.html) for more details on how to set one on IDEA):
 
         Package pkg = target.getClass().getPackage();
         if (pkg == null) {

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -146,8 +146,8 @@ In order to debug your scenarios on the JVM, you can step through the the steps 
 2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode
 3. Assuming you haven't set any other breakpoints, the execution will stop at `Utils#invoke`
 4. Now you can either:
-   - _Step into_ to start debugging the method implementing the first step of the scenario
-   - Or _Resume_ the execution to run the current step and jump to the next one
+   - *Step into* to start debugging the method implementing the first step of the scenario
+   - Or *Resume* the execution to run the current step and jump to the next one
 5. And so on..
 {{% /block %}}
 

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -144,9 +144,11 @@ Package pkg = target.getClass().getPackage();
   }
   return !target.getClass().getPackage().getName().startsWith("cucumber");
 ```
+
 For more details on how to set a breakpoint in your IDE, see:
-   - [Breakpoints - IntelliJ](https://www.jetbrains.com/help/idea/breakpoints.html)
-   - [Debugging - Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
+   - [Breakpoints (IntelliJ)](https://www.jetbrains.com/help/idea/breakpoints.html)
+   - [Debugging (Eclipse)](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
+   
 2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode
 3. Assuming you haven't set any other breakpoints, the execution will stop at `Utils#invoke`
 4. Now you can either:

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -145,11 +145,8 @@ Package pkg = target.getClass().getPackage();
   return !target.getClass().getPackage().getName().startsWith("cucumber");
 ```
 For more details on how to set a breakpoint in your IDE, see:
-
-* [Breakpoints - IntelliJ](https://www.jetbrains.com/help/idea/breakpoints.html)
-
-* [Debugging - Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
-
+- [Breakpoints - IntelliJ](https://www.jetbrains.com/help/idea/breakpoints.html)
+- [Debugging - Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
 2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode
 3. Assuming you haven't set any other breakpoints, the execution will stop at `Utils#invoke`
 4. Now you can either:

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -129,7 +129,7 @@ def wait_until_jquery_inactive
   end
 end
 ```
-By setting an environment variable, you can cause Cucumber to use various debugging tools, and you can combine them by setting multiple environment variables.
+By setting an environment variable, you can tell Cucumber to use various debugging tools, and you can combine them by setting multiple environment variables.
 {{% /block %}}
 
 {{% block "java" %}}

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -153,6 +153,8 @@ Package pkg = target.getClass().getPackage();
 5. And so on..
 
 For more details on how to set a breakpoint in your IDE, see:
-   - [Breakpoints (IntelliJ)](https://www.jetbrains.com/help/idea/breakpoints.html)
-   - [Debugging (Eclipse)](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
+
+* [Breakpoints (IntelliJ)](https://www.jetbrains.com/help/idea/breakpoints.html)
+
+* [Debugging (Eclipse)](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
 {{% /block %}}

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -135,7 +135,7 @@ By setting an environment variable, you can tell Cucumber to use various debuggi
 {{% block "java" %}}
 In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. The example below uses IntelliJ, but Eclipse will have similar functionality.
 
-1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html](https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html) for more details on how to set one on IDEA):
+1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [Breakpoints](https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html) for more details on how to set one on IDEA):
 
         Package pkg = target.getClass().getPackage();
         if (pkg == null) {

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -131,9 +131,12 @@ By setting an environment variable, you can tell Cucumber to use various debuggi
 {{% block "java" %}}
 In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. 
 
-1. Set a conditional breakpoint on the part of the code you want to debug. 
+1. Set a conditional breakpoint on the part of the code you want to debug.
+
 This might be the line you are currently getting an Exception (see your stacktrace). 
+
 Or, if you don't know where to start, you can set a breakpoint in the method [`cucumber.runtime.Utils#invoke`](https://github.com/cucumber/cucumber-jvm/blob/master/core/src/main/java/cucumber/runtime/Utils.java), at the line `return targetMethod.invoke(target, args)` (line 26 in `cucumber-jvm` master at the time of writing) and specify the following snippet as the condition: 
+
 ```java
 Package pkg = target.getClass().getPackage();
   if (pkg == null) {

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -6,10 +6,6 @@ polyglot:
  - ruby
 
 ---
-
-
-# Debugging failing Cucumber steps
-
 {{% block "ruby" %}}
 (The code given below calls on [the logging facilities of Ruby on Rails](https://guides.rubyonrails.org/debugging_rails_applications.html#the-logger). If you're not using Rails, replace those calls with `puts` or `warn`.)
 
@@ -133,11 +129,11 @@ By setting an environment variable, you can tell Cucumber to use various debuggi
 {{% /block %}}
 
 {{% block "java" %}}
-In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. The example below uses IntelliJ, but Eclipse will have similar functionality.
+In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. 
 
-1. Set a conditional breakpoint on th epart of the code you want to debug. 
+1. Set a conditional breakpoint on the part of the code you want to debug. 
 This might be the line you are currently getting an Exception (see your stacktrace). 
-Or, if you don't know where to start, you can set a breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 26 in `cucumber-jvm` master at the time of writing) and specify the following snippet as the condition: 
+Or, if you don't know where to start, you can set a breakpoint in the method [`cucumber.runtime.Utils#invoke`](https://github.com/cucumber/cucumber-jvm/blob/master/core/src/main/java/cucumber/runtime/Utils.java), at the line `return targetMethod.invoke(target, args)` (line 26 in `cucumber-jvm` master at the time of writing) and specify the following snippet as the condition: 
 ```java
 Package pkg = target.getClass().getPackage();
   if (pkg == null) {
@@ -146,7 +142,9 @@ Package pkg = target.getClass().getPackage();
   return !target.getClass().getPackage().getName().startsWith("cucumber");
 ```
 For more details on how to set a breakpoint in your IDE, see:
+
 * [Breakpoints - IntelliJ](https://www.jetbrains.com/help/idea/breakpoints.html)
+
 * [Debugging - Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2017/june/article1.php)
 
 2. Run your [RunCukesTest](https://github.com/cucumber/cucumber-java-skeleton/blob/master/src/test/java/skeleton/RunCukesTest.java) in debug mode

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -133,7 +133,7 @@ By setting an environment variable, you can tell Cucumber to use various debuggi
 {{% /block %}}
 
 {{% block "java" %}}
-Here is an IntelliJ example on how to debug your scenarios on the JVM, by stepping through the steps of each scenario:
+In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. The example below uses IntelliJ, but Eclipse will have similar functionality.
 
 1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html](https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html) for more details on how to set one on IDEA):
 

--- a/content/cucumber/debugging.md
+++ b/content/cucumber/debugging.md
@@ -133,7 +133,7 @@ By setting an environment variable, you can tell Cucumber to use various debuggi
 {{% /block %}}
 
 {{% block "java" %}}
-Here is how to debug your scenarios on the JVM, by stepping through the steps of each scenario:
+Here is an IntelliJ example on how to debug your scenarios on the JVM, by stepping through the steps of each scenario:
 
 1. Set a conditional breakpoint in the method `cucumber.runtime.Utils#invoke`, at the line `return targetMethod.invoke(target, args)` (line 40 in `cucumber-jvm` v1.2.5) and specify the following snippet as the condition (see also [https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html](https://www.jetbrains.com/help/idea/2017.1/breakpoints-2.html) for more details on how to set one on IDEA):
 


### PR DESCRIPTION
Same as #210.

# TODO to complete this article

- [ ] JVM information is quite old (Cucumber v1.2.5 and IntelliJ 2017.1) - update it to newer versions
- [ ] add some JavaScript debugging tips (note to self: see the [Cucumber-js](https://github.com/cucumber/cucumber-js) documentation)


