### PR TITLE
Use 'end' instead of })

### DIFF
--- a/content/cucumber/api.md
+++ b/content/cucumber/api.md
@@ -270,7 +270,7 @@ After(function (scenario) {
 
 ```ruby
 After do |scenario|
-})
+end
 ```
 
 {{% /block %}}


### PR DESCRIPTION
Incorrect ending of block in ruby example