### PR TITLE
Document that `Scenario` is a synonym of `Example`

### DIFF
--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -93,7 +93,7 @@ Free-form descriptions (as described above for `Feature`) can also be placed und
 
 You can write anything you like, as long as no line starts with a keyword.
 
-## Example
+## Example (a.k.a Scenario)
 
 This is a *concrete example* that *illustrates* a business rule. It consists of
 a list of [steps](#steps).

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -93,7 +93,7 @@ Free-form descriptions (as described above for `Feature`) can also be placed und
 
 You can write anything you like, as long as no line starts with a keyword.
 
-## Example (a.k.a Scenario)
+## Example
 
 This is a *concrete example* that *illustrates* a business rule. It consists of
 a list of [steps](#steps).

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -39,7 +39,7 @@ Each line that isn't a blank line has to start with a Gherkin *keyword*, followe
 The primary keywords are:
 
 - `Feature`
-- `Example` (`Scenario` and `Scenario Outline` are synonyms)
+- `Example` (`Scenario` is a synonym)
 - `Given`, `When`, `Then`, `And`, `But`  (steps)
 - `Background`
 - `Examples`
@@ -97,6 +97,8 @@ You can write anything you like, as long as no line starts with a keyword.
 
 This is a *concrete example* that *illustrates* a business rule. It consists of
 a list of [steps](#steps).
+
+The keyword `Scenario` is a synonym of the keyword `Example`.
 
 You can have as many steps as you like, but we recommend you keep the number at 3-5 per scenario.
 If they become longer than that, they lose their expressive power as specification and documentation.

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -39,7 +39,7 @@ Each line that isn't a blank line has to start with a Gherkin *keyword*, followe
 The primary keywords are:
 
 - `Feature`
-- `Example` (`Scenario` is a synonym)
+- `Example` (a.k.a `Scenario`)
 - `Given`, `When`, `Then`, `And`, `But`  (steps)
 - `Background`
 - `Examples`

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -39,9 +39,10 @@ Each line that isn't a blank line has to start with a Gherkin *keyword*, followe
 The primary keywords are:
 
 - `Feature`
-- `Example` (a.k.a `Scenario`)
+- `Example` (or `Scenario`)
 - `Given`, `When`, `Then`, `And`, `But`  (steps)
 - `Background`
+- `Scenario Outline` (or `Scenario Template`)
 - `Examples`
 
 There are a few secondary keywords as well:
@@ -286,6 +287,8 @@ Think about using higher-level steps, or splitting the `*.feature` file.
 The `Scenario Outline` keyword can be used to run the same `Scenario` multiple times,
 with different combinations of values.
 
+The keyword `Scenario Template` is a synonym of the keyword `Scenario Outline`.
+
 Copying and pasting scenarios to use different values quickly becomes tedious and repetitive:
 
 ```gherkin
@@ -317,7 +320,7 @@ Scenario Outline: eating
     |    20 |   5 |   15 |
 ```
 
-A `Scenario Outline` must contain an `Examples` section. Its steps are interpreted as a template
+A `Scenario Outline` must contain an `Examples` (or `Scenarios`) section. Its steps are interpreted as a template
 which is never directly run. Instead, the `Scenario Outline` is run *once for each row* in
 the `Examples` section beneath it (not counting the first header row).
 


### PR DESCRIPTION
Also removed the text that implied `Scenario Outline` is a synonym, since clearly from the rest of the document `Scenario Outline` is different from `Example`.