### PR TITLE
Eliminate Syntax oddities with IntelliJ

### DIFF
--- a/content/guides/10-minute-tutorial.md
+++ b/content/guides/10-minute-tutorial.md
@@ -95,7 +95,7 @@ mvn archetype:generate                      \
    -DartifactId=hellocucumber               \
    -Dpackage=hellocucumber                  \
    -Dversion=1.0.0-SNAPSHOT                 \
-   -DinteractiveMode=false
+   -DinteractiveMode=false                  \
 ```
 
 You should get something like the following result:
@@ -1388,15 +1388,15 @@ Feature: Is it Friday yet?
   Everybody wants to know when it's Friday
 
   Scenario Outline: Today is or is not Friday
-    Given today is <day>
+    Given today is "<day>"
     When I ask whether it's Friday yet
-    Then I should be told <answer>
+    Then I should be told "<answer>"
 
   Examples:
     | day | answer |
-    | "Friday" | "TGIF" |
-    | "Sunday" | "Nope" |
-    | "anything else!" | "Nope" |
+    | Friday | TGIF |
+    | Sunday | Nope |
+    | anything else! | Nope |
 ```
 
 We need to replace the step definitions for `today is Sunday` and `today is Friday` with one step definition that takes the value of `<day>` as a String.


### PR DESCRIPTION
When I follow the tutorial and get to the section on creating an outline and providing examples, I get a couple of syntax errors that can be easily remedied with a few changes to where you put quotation marks in the .feature file. Instead of putting quotation marks around every argument in the examples table, put quotation marks around the parameterized terms in the 'Given' and 'Then' statements. This takes care of:
1. IntelliJ telling me I need to implement step definitions for what is technically a different format than what is provided in the doc already, and
2. Spellchecker telling me there's a spelling issue with each of the items in the examples table.