### PR TITLE
Add docs for custom formatters (only Ruby examples)

### DIFF
--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -271,49 +271,10 @@ end
 ```
 
 ### Configuration object
-The formatter initializer is passed a `Cucumber::Configuration` object. This is the configuration for the test run,
-including default configurations and options passed in at the command line. It can be useful to access these options
-so that your formatter can modify its behavior in response to user directives.
-
-The configuration object responds to a number of useful methods, including the following:
-* `#all_files_to_load`: An array of the paths to the files being loaded, as strings
-* `#autoload_code_paths`: An array of the directories that are autoloaded by Cucumber, for example, `features/support`
-* `#custom_profiles`: An array containing any custom profiles that have been added to the test run
-* `#dry_run?`: A boolean indicating whether the `--dry-run` option has been specified (`false` by default)
-* `#duration?`: A boolean indicating whether the `--duration` option has been specified (`true` by default)
-* `#error_stream`: The `IO` object or file to which errors will be written
-* `#expand?`: A boolean indicating whether the `--expand` option has been specified (`false` by default)
-* `#fail_fast?`: A boolean indicating whether the `--fail-fast` option has been specified (`false` by default)
-* `#feature_dirs`: An array of the directories containing features, including default directories and others
-  specified as options to the test run
-* `#feature_files`: An array of the paths of feature files to be included in the test run
-* `#filters`: An array of filters specified in the options
-* `#formats`: An array of the formatters used with the output stream as the final element
-* `#guess?`: A boolean indicating whether the `--guess` option has been specified (`false` by default)
-* `#name_regexps`: An array of regular expressions indicating which features to run (passed in using the `--name` option
-  or in the `cucumber.yml` config file)
-* `#out_stream`: The `IO` object or file to which formatter output will be written
-* `#paths`: The paths to the files being run
-* `#profiles`: An array of the profiles being used for the test run
-* `#randomize?`: A boolean indicating whether the features are to be run in random order (`false` by default)
-* `#retry_attempts`: The number of times flaky tests are to be rerun if the `--retry` option is used
-* `#seed`: The seed used to randomize test runs if the `--order=random` option is used
-* `#skip_profile_information?`: A boolean indicating whether profile information should be skipped (`nil` by default)
-* `#snippet_generators`: An array of the snippet generators used, by default containing `Cucumber::Glue::Snippet::Generator`
-  objects
-* `#snippet_type`: A symbol indicating the type of snippet to be used (`:cucumber_expression` by default)
-* `#snippets?`: A boolean indicating whether snippets are to be generated for undefined steps (`true` by default)
-* `#source?`: A boolean indicating whether the file and line of the step definition should be printed with the output for
-  each step (`true` by default)
-* `#step_defs_to_load`: An array of the step definition files to be loaded for the test run
-* `#strict`: The `strict` setting to be applied to the test run (by default an instance of `Cucumber::Core::Test::Result::StrictConfiguration`)
-* `#support_to_load`: An array of the paths to support files to be loaded for the test run
-* `#tag_expressions`: An array of the tag expressions indicated at the command line or in the `cucumber.yml` config
-  file (empty by default)
-* `#tag_limits`: A hash of tag limits to be used (empty by default)
-* `#to_hash`: The options hash being used for the test run
-* `#wip?`: A boolean indicating whether the `--wip` option has been specified (`false` by default)
-* `#with_options`: A new config object merging existing options with a new options hash passed in as an argument
+The formatter initializer is passed a `Cucumber::Configuration` object. This is the 
+[configuration for the test run](https://docs.cucumber.io/cucumber/configuration/),
+including default configurations and [options](https://docs.cucumber.io/cucumber/api/) passed in at the command line.
+It can be useful to access these options so that your formatter can modify its behavior in response to user directives.
 
 ### Event objects
 Every time an event is fired, an event object is passed to the corresponding handler. Each event object belongs to

--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -3,6 +3,7 @@ title: Reporting
 subtitle: "Built-in reporter plugins, Cucumber Pro, Third-party plugins"
 polyglot:
 - java
+- ruby
 - dotnet
 ---
 

--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -308,17 +308,17 @@ The `test_run_started` event is fired at the beginning of the test run. It has o
   of these objects responds to the following instance methods:
     - `#all_locations`: Returns an array with the location of each element (feature, scenario, and step) in the feature
       file for the test case.
-    - `#all_source`: Returns an array of the features, scenarios, and steps in the test case, as strings, less the keywords
+    - `#all_source`: Returns an array of the features, scenarios, and steps in the test case, as strings, without the keywords
     - `#around_hooks`: Returns an array of the Around hooks associated with that test case
     - `#feature`: Returns the name of the feature for the test case
-    - `#keyword`: Returns the keyword associated with the test case (`"Feature"`, `"Scenario"`, etc.)
+    - `#keyword`: Returns the Gherkin keyword associated with the test case (`"Feature"`, `"Scenario"`, etc.)
     - `#language`: Returns the language indicated for the test case, as a `Gherkin::Dialect` object
     - `#location`: Returns the location of the first scenario in the test case
     - `#name`: Returns the name of the feature for the test case
-    - `#source`: Returns the names of the features and scenarios in the test case, as strings, less the keywords
+    - `#source`: Returns the names of the features and scenarios in the test case, as strings, without the keywords
     - `#step_count`: Returns the integer number of steps in the test case
     - `#tags`: Returns an array of tags for the test case
-    - `#test_steps`: Returns an array of the steps in the test case, less the keywords
+    - `#test_steps`: Returns an array of the steps in the test case, without the keywords
 
 #### test_run_finished
 The `test_run_finished` event is fired after the test run has finished. It has no additional attributes or methods
@@ -345,7 +345,7 @@ The `step_activated` event is fired when a test step has been activated. It has 
     - `#location`: The step definition file where the step is defined
     - `#step_arguments`: The arguments passed to the step
     - `#step_definition`: The `Cucumber::Glue::StepDefinition` object (described above) corresponding to the step
-    - `#text_length`: The integer length, in characters, of the step text
+    - `#text_length`: The number of characters in the step text
 
 #### test_step_started
 The `test_step_started` event is fired just before each `Cucumber::Core::Test::Step` is started. It has one attribute:
@@ -355,8 +355,8 @@ The `test_step_started` event is fired just before each `Cucumber::Core::Test::S
       in the form `features/file.feature:line`
     - `#location`: The feature file in which the step appears and the location of the step within that file, in the same
       form as described under `#action_location`
-    - `#source`: The Gherkin source of the feature file in which the step appears, less keywords
-    - `#text`: The text of the step, less its keyword
+    - `#source`: The Gherkin source of the feature file in which the step appears, without keywords
+    - `#text`: The text of the step, without the Gherkin keyword
 
 #### test_step_finished
 The `test_step_finished` event is fired after each `Cucumber::Core::Test::Step` has finished running. It has two attributes:

--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -235,6 +235,134 @@ Alternatively, you can specify a Java system property (in Maven, Gradle or other
 ```
 {{% /block %}}
 
+# Custom formatters
+The Cucumber formatter API is easily extensible. A formatter can be any class implementing the event-based formatter
+API. The formatter class should live in the `features/support` directory, or alternatively, may be required when you
+run Cucumber using the `--dir` flag. To use your custom formatter, run Cucumber using the `--format` flag:
+```
+# Assumes CustomFormatter class is housed in the features/support directory
+cucumber --format CustomFormatter
+# Requires the directory containing the custom formatter
+cucumber --format CustomFormatter --dir formatters
+```
+
+## Formatter API
+Cucumber uses an event-based API for its formatters. These formatters respond to several defined events, with
+event handlers defined in the `#initialize` method of the formatter. A sample formatter could look like this:
+
+```ruby
+class CustomFormatter
+  attr_reader :io
+
+  def initialize(config)
+    @io = config.out_stream
+
+    # Using a block
+    config.on_event :test_step_started do |event|
+      io.puts 'Started test step'
+    end
+
+    # Passing in a method
+    config.on_event :test_step_finished &method(:print_finished)
+  end
+
+  def print_finished(event)
+    io.puts 'Finished test step'
+  end
+end
+```
+
+### Formatter configuration object
+
+### Event objects
+Every time an event is fired, an event object is passed to the corresponding handler. Each event object belongs to
+a class corresponding to its name; for instance, the `gherkin_source_read` event creates a
+`Cucumber::Events::GherkinSourceRead` object. Each of these objects provides a different API to access relevant
+data such as Gherkin source, feature and step names, and passed/failed status of a step or test case. All events
+inherit the methods `#attributes`, `#event_id`, and `#to_h` from the parent class.
+
+#### gherkin_source_read
+The `gherkin_source_read` event is fired after the contents of a new feature file have been read. It has two
+attributes:
+* `path`: The file path of the feature file that has been read
+* `body`: The raw Gherkin contained in that file, as a string
+
+#### step_definition_registered
+The `step_definition_registered` event is fired after each step definition has been registered. It has one
+attribute:
+* `step_definition`: The `Cucumber::Glue::StepDefinition` object that has just been registered. This object responds
+  to the following instance methods:
+    - `#backtrace_line`: The file, line, and step definition that will appear in a backtrace, as in:
+      `features/step_definitions/cuke_steps.rb:5:in "this step passes"`
+    - `#expression`: The expression used in the step definition, as in `"I have {int} cukes in my belly"` (when a
+      Cucumber expression is used) or `/I have (\d+) cukes in my belly/` (when a regular expression is used)
+    - `#file`: The file where the step definition occurs, as a string, as in `"features/step_definitions/cuke_steps.rb"`
+    - `#file_colon_line`: The file and line where the step definition occurs, as a string, as in
+      `"features/step_definitions/cuke_steps.rb:5"`
+    - `#location`: Alias of `#file_colon_line`
+    - `#to_hash`: A hash of data about the step definition, such as `{:source=>{:type=>"cucumber expression", :expression=>"I fail"}, :regexp=>{:source=>"^I fail$", :flags=>""}}`
+
+#### test_run_started
+The `test_run_started` event is fired at the beginning of the test run. It has one attribute:
+* `test_cases`: The test cases included in the test run. This is an array of `Cucumber::Core::Test::Case` objects. Each
+  of these objects responds to the following instance methods:
+    - `#all_locations`: Returns an array with the location of each element (feature, scenario, and step) in the feature
+      file for the test case.
+    - `#all_source`: Returns an array of the features, scenarios, and steps in the test case, as strings, less the keywords
+    - `#around_hooks`: Returns an array of the Around hooks associated with that test case
+    - `#feature`: Returns the name of the feature for the test case
+    - `#keyword`: Returns the keyword associated with the test case (`"Feature"`, `"Scenario"`, etc.)
+    - `#language`: Returns the language indicated for the test case, as a `Gherkin::Dialect` object
+    - `#location`: Returns the location of the first scenario in the test case
+    - `#name`: Returns the name of the feature for the test case
+    - `#source`: Returns the names of the features and scenarios in the test case, as strings, less the keywords
+    - `#step_count`: Returns the integer number of steps in the test case
+    - `#tags`: Returns an array of tags for the test case
+    - `#test_steps`: Returns an array of the steps in the test case, less the keywords
+
+#### test_run_finished
+The `test_run_finished` event is fired after the test run has finished. It has no additional attributes or methods
+defined beyond those defined on the base event class (i.e., `#attributes`, `#event_id` and `#to_h`), meaning you cannot
+access test cases, Gherkin source, etc. from the handler for this event. This event can be used, for example, to print
+the running time of the test suite.
+
+#### test_case_started
+The `test_case_started` event is fired when a `Cucumber::Core::Test::Case` is about to be executed. It has one attribute:
+* `test_case`: The `Cucumber::Core::Test::Case` object (described above) that is about to be executed.
+
+#### test_case_finished
+The `test_case_finished` event is fired when a `Cucumber::Core::Test::Case` has finished executing. It has two attributes:
+* `test_case`: The `Cucumber::Core::Test::Case` object (described above) that has just finished
+* `result`: The result (passed, failed, pending, skipped) of the test case
+
+#### step_activated
+The `step_activated` event is fired when a test step has been activated. It has two attributes:
+* `test_step`: The `Cucumber::Core::Test::Step` object (described above) that has been activated
+* `step_match`: A `Cucumber::StepMatch` object. This object responds to the following instance methods:
+    - `#args`: The arguments passed to the step
+    - `#backtrace_line`: The backtrace line from the step definition including the file, line, and step expression
+    - `#format_args`: The text of the step
+    - `#location`: The step definition file where the step is defined
+    - `#step_arguments`: The arguments passed to the step
+    - `#step_definition`: The `Cucumber::Glue::StepDefinition` object (described above) corresponding to the step
+    - `#text_length`: The integer length, in characters, of the step text
+
+#### test_step_started
+The `test_step_started` event is fired just before each `Cucumber::Core::Test::Step` is started. It has one attribute:
+* `test_step`: The `Cucumber::Core::Test::Step` object that has just started. This object responds to the following
+  methods that may be useful for the purposes of your formatter:
+    - `#action_location`: The feature file in which the step appears and the location of its scenario within that file,
+      in the form `features/file.feature:line`
+    - `#location`: The feature file in which the step appears and the location of the step within that file, in the same
+      form as described under `#action_location`
+    - `#source`: The Gherkin source of the feature file in which the step appears, less keywords
+    - `#text`: The text of the step, less its keyword
+
+#### test_step_finished
+The `test_step_finished` event is fired after each `Cucumber::Core::Test::Step` has finished running. It has two attributes:
+* `test_step`: The `Cucumber::Core::Test::Step` object (described above) that has just executed
+* `result` The result (passed, failed, pending, skipped) of the test case
+
 # Third-party plugins
 There are also many third-party plugins:
 

--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -237,14 +237,11 @@ Alternatively, you can specify a Java system property (in Maven, Gradle or other
 {{% /block %}}
 
 # Custom formatters
-The Cucumber formatter API is easily extensible. A formatter can be any class implementing the event-based formatter
-API. The formatter class should live in the `features/support` directory, or alternatively, may be required when you
-run Cucumber using the `--dir` flag. To use your custom formatter, run Cucumber using the `--format` flag:
+The Cucumber formatter API is readily extensible. A formatter can be any class implementing the event-based formatter
+API. The formatter class should live in the `features/support` directory. To use your custom formatter, run Cucumber
+using the `--format` flag:
 ```
-# Assumes CustomFormatter class is housed in the features/support directory
 cucumber --format CustomFormatter
-# Requires the directory containing the custom formatter
-cucumber --format CustomFormatter --dir formatters
 ```
 
 ## Formatter API

--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -272,7 +272,50 @@ class CustomFormatter
 end
 ```
 
-### Formatter configuration object
+### Configuration object
+The formatter initializer is passed a `Cucumber::Configuration` object. This is the configuration for the test run,
+including default configurations and options passed in at the command line. It can be useful to access these options
+so that your formatter can modify its behavior in response to user directives.
+
+The configuration object responds to a number of useful methods, including the following:
+* `#all_files_to_load`: An array of the paths to the files being loaded, as strings
+* `#autoload_code_paths`: An array of the directories that are autoloaded by Cucumber, for example, `features/support`
+* `#custom_profiles`: An array containing any custom profiles that have been added to the test run
+* `#dry_run?`: A boolean indicating whether the `--dry-run` option has been specified (`false` by default)
+* `#duration?`: A boolean indicating whether the `--duration` option has been specified (`true` by default)
+* `#error_stream`: The `IO` object or file to which errors will be written
+* `#expand?`: A boolean indicating whether the `--expand` option has been specified (`false` by default)
+* `#fail_fast?`: A boolean indicating whether the `--fail-fast` option has been specified (`false` by default)
+* `#feature_dirs`: An array of the directories containing features, including default directories and others
+  specified as options to the test run
+* `#feature_files`: An array of the paths of feature files to be included in the test run
+* `#filters`: An array of filters specified in the options
+* `#formats`: An array of the formatters used with the output stream as the final element
+* `#guess?`: A boolean indicating whether the `--guess` option has been specified (`false` by default)
+* `#name_regexps`: An array of regular expressions indicating which features to run (passed in using the `--name` option
+  or in the `cucumber.yml` config file)
+* `#out_stream`: The `IO` object or file to which formatter output will be written
+* `#paths`: The paths to the files being run
+* `#profiles`: An array of the profiles being used for the test run
+* `#randomize?`: A boolean indicating whether the features are to be run in random order (`false` by default)
+* `#retry_attempts`: The number of times flaky tests are to be rerun if the `--retry` option is used
+* `#seed`: The seed used to randomize test runs if the `--order=random` option is used
+* `#skip_profile_information?`: A boolean indicating whether profile information should be skipped (`nil` by default)
+* `#snippet_generators`: An array of the snippet generators used, by default containing `Cucumber::Glue::Snippet::Generator`
+  objects
+* `#snippet_type`: A symbol indicating the type of snippet to be used (`:cucumber_expression` by default)
+* `#snippets?`: A boolean indicating whether snippets are to be generated for undefined steps (`true` by default)
+* `#source?`: A boolean indicating whether the file and line of the step definition should be printed with the output for
+  each step (`true` by default)
+* `#step_defs_to_load`: An array of the step definition files to be loaded for the test run
+* `#strict`: The `strict` setting to be applied to the test run (by default an instance of `Cucumber::Core::Test::Result::StrictConfiguration`)
+* `#support_to_load`: An array of the paths to support files to be loaded for the test run
+* `#tag_expressions`: An array of the tag expressions indicated at the command line or in the `cucumber.yml` config
+  file (empty by default)
+* `#tag_limits`: A hash of tag limits to be used (empty by default)
+* `#to_hash`: The options hash being used for the test run
+* `#wip?`: A boolean indicating whether the `--wip` option has been specified (`false` by default)
+* `#with_options`: A new config object merging existing options with a new options hash passed in as an argument
 
 ### Event objects
 Every time an event is fired, an event object is passed to the corresponding handler. Each event object belongs to

--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -246,7 +246,9 @@ cucumber --format CustomFormatter
 
 ## Formatter API
 Cucumber uses an event-based API for its formatters. These formatters respond to several defined events, with
-event handlers defined in the `#initialize` method of the formatter. A sample formatter could look like this:
+event handlers defined in the formatter's constructor. A sample formatter could look like this:
+
+{{% block "ruby" %}}
 
 ```ruby
 class CustomFormatter
@@ -269,6 +271,7 @@ class CustomFormatter
   end
 end
 ```
+{{% /block %}}
 
 ### Configuration object
 The formatter initializer is passed a `Cucumber::Configuration` object. This is the 
@@ -297,7 +300,7 @@ attribute:
     - `#backtrace_line`: The file, line, and step definition that will appear in a backtrace, as in:
       `features/step_definitions/cuke_steps.rb:5:in "this step passes"`
     - `#expression`: The expression used in the step definition, as in `"I have {int} cukes in my belly"` (when a
-      Cucumber expression is used) or `/I have (\d+) cukes in my belly/` (when a regular expression is used)
+      Cucumber expression is used) or `/^I have (\d+) cukes in my belly$/` (when a regular expression is used)
     - `#file`: The file where the step definition occurs, as a string, as in `"features/step_definitions/cuke_steps.rb"`
     - `#file_colon_line`: The file and line where the step definition occurs, as a string, as in
       `"features/step_definitions/cuke_steps.rb:5"`

--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -238,18 +238,16 @@ Alternatively, you can specify a Java system property (in Maven, Gradle or other
 
 # Custom formatters
 The Cucumber formatter API is readily extensible. A formatter can be any class implementing the event-based formatter
-API. The formatter class should live in the `features/support` directory. To use your custom formatter, run Cucumber
-using the `--format` flag:
+API. {{% text "ruby" %}}The formatter class should live in the `features/support` directory. {{% /text %}}To use your custom formatter, run Cucumber using the `--format` flag:
 ```
 cucumber --format CustomFormatter
 ```
 
 ## Formatter API
 Cucumber uses an event-based API for its formatters. These formatters respond to several defined events, with
-event handlers defined in the formatter's constructor. A sample formatter could look like this:
-
+event handlers defined in the formatter's constructor. 
 {{% block "ruby" %}}
-
+A sample formatter could look like this:
 ```ruby
 class CustomFormatter
   attr_reader :io
@@ -274,17 +272,18 @@ end
 {{% /block %}}
 
 ### Configuration object
-The formatter initializer is passed a `Cucumber::Configuration` object. This is the 
+The formatter initializer is passed a {{% text "java,dotnet" %}}Cucumber configuration{{% /text %}}{{% text "ruby" %}}`Cucumber::Configuration`{{% /text %}} object. This is the 
 [configuration for the test run](https://docs.cucumber.io/cucumber/configuration/),
 including default configurations and [options](https://docs.cucumber.io/cucumber/api/) passed in at the command line.
-It can be useful to access these options so that your formatter can modify its behavior in response to user directives.
+It can be useful to access these options, so that your formatter can modify its behavior in response to user directives.
 
 ### Event objects
 Every time an event is fired, an event object is passed to the corresponding handler. Each event object belongs to
-a class corresponding to its name; for instance, the `gherkin_source_read` event creates a
-`Cucumber::Events::GherkinSourceRead` object. Each of these objects provides a different API to access relevant
-data such as Gherkin source, feature and step names, and passed/failed status of a step or test case. All events
-inherit the methods `#attributes`, `#event_id`, and `#to_h` from the parent class.
+a class corresponding to its name. {{% text "ruby" %}}For instance, the `gherkin_source_read` event creates a
+`Cucumber::Events::GherkinSourceRead` object.{{% /text %}} Each of these objects provides a different API to access relevant
+data such as Gherkin source, feature and step names, and passed/failed status of a step or test case. {{% text "ruby" %}}All events inherit the methods `#attributes`, `#event_id`, and `#to_h` from the parent class.{{% /text %}}
+
+**Note:** Following are the event objects for Cucumber Ruby; other programming languages might have slightly different events.
 
 #### gherkin_source_read
 The `gherkin_source_read` event is fired after the contents of a new feature file have been read. It has two
@@ -297,33 +296,33 @@ The `step_definition_registered` event is fired after each step definition has b
 attribute:
 * `step_definition`: The `Cucumber::Glue::StepDefinition` object that has just been registered. This object responds
   to the following instance methods:
-    - `#backtrace_line`: The file, line, and step definition that will appear in a backtrace, as in:
+- `#backtrace_line`: The file, line, and step definition that will appear in a backtrace, as in:
       `features/step_definitions/cuke_steps.rb:5:in "this step passes"`
-    - `#expression`: The expression used in the step definition, as in `"I have {int} cukes in my belly"` (when a
+- `#expression`: The expression used in the step definition, as in `"I have {int} cukes in my belly"` (when a
       Cucumber expression is used) or `/^I have (\d+) cukes in my belly$/` (when a regular expression is used)
-    - `#file`: The file where the step definition occurs, as a string, as in `"features/step_definitions/cuke_steps.rb"`
-    - `#file_colon_line`: The file and line where the step definition occurs, as a string, as in
+- `#file`: The file where the step definition occurs, as a string, as in `"features/step_definitions/cuke_steps.rb"`
+- `#file_colon_line`: The file and line where the step definition occurs, as a string, as in
       `"features/step_definitions/cuke_steps.rb:5"`
-    - `#location`: Alias of `#file_colon_line`
-    - `#to_hash`: A hash of data about the step definition, such as `{:source=>{:type=>"cucumber expression", :expression=>"I fail"}, :regexp=>{:source=>"^I fail$", :flags=>""}}`
+- `#location`: Alias of `#file_colon_line`
+- `#to_hash`: A hash of data about the step definition, such as `{:source=>{:type=>"cucumber expression", :expression=>"I fail"}, :regexp=>{:source=>"^I fail$", :flags=>""}}`
 
 #### test_run_started
 The `test_run_started` event is fired at the beginning of the test run. It has one attribute:
 * `test_cases`: The test cases included in the test run. This is an array of `Cucumber::Core::Test::Case` objects. Each
   of these objects responds to the following instance methods:
-    - `#all_locations`: Returns an array with the location of each element (feature, scenario, and step) in the feature
+- `#all_locations`: Returns an array with the location of each element (feature, scenario, and step) in the feature
       file for the test case.
-    - `#all_source`: Returns an array of the features, scenarios, and steps in the test case, as strings, without the keywords
-    - `#around_hooks`: Returns an array of the Around hooks associated with that test case
-    - `#feature`: Returns the name of the feature for the test case
-    - `#keyword`: Returns the Gherkin keyword associated with the test case (`"Feature"`, `"Scenario"`, etc.)
-    - `#language`: Returns the language indicated for the test case, as a `Gherkin::Dialect` object
-    - `#location`: Returns the location of the first scenario in the test case
-    - `#name`: Returns the name of the feature for the test case
-    - `#source`: Returns the names of the features and scenarios in the test case, as strings, without the keywords
-    - `#step_count`: Returns the integer number of steps in the test case
-    - `#tags`: Returns an array of tags for the test case
-    - `#test_steps`: Returns an array of the steps in the test case, without the keywords
+- `#all_source`: Returns an array of the features, scenarios, and steps in the test case, as strings, without the keywords
+- `#around_hooks`: Returns an array of the Around hooks associated with that test case
+- `#feature`: Returns the name of the feature for the test case
+- `#keyword`: Returns the Gherkin keyword associated with the test case (`"Feature"`, `"Scenario"`, etc.)
+- `#language`: Returns the language indicated for the test case, as a `Gherkin::Dialect` object
+- `#location`: Returns the location of the first scenario in the test case
+- `#name`: Returns the name of the feature for the test case
+- `#source`: Returns the names of the features and scenarios in the test case, as strings, without the keywords
+- `#step_count`: Returns the integer number of steps in the test case
+- `#tags`: Returns an array of tags for the test case
+- `#test_steps`: Returns an array of the steps in the test case, without the keywords
 
 #### test_run_finished
 The `test_run_finished` event is fired after the test run has finished. It has no additional attributes or methods
@@ -344,24 +343,24 @@ The `test_case_finished` event is fired when a `Cucumber::Core::Test::Case` has 
 The `step_activated` event is fired when a test step has been activated. It has two attributes:
 * `test_step`: The `Cucumber::Core::Test::Step` object (described above) that has been activated
 * `step_match`: A `Cucumber::StepMatch` object. This object responds to the following instance methods:
-    - `#args`: The arguments passed to the step
-    - `#backtrace_line`: The backtrace line from the step definition including the file, line, and step expression
-    - `#format_args`: The text of the step
-    - `#location`: The step definition file where the step is defined
-    - `#step_arguments`: The arguments passed to the step
-    - `#step_definition`: The `Cucumber::Glue::StepDefinition` object (described above) corresponding to the step
-    - `#text_length`: The number of characters in the step text
+- `#args`: The arguments passed to the step
+- `#backtrace_line`: The backtrace line from the step definition including the file, line, and step expression
+- `#format_args`: The text of the step
+- `#location`: The step definition file where the step is defined
+- `#step_arguments`: The arguments passed to the step
+- `#step_definition`: The `Cucumber::Glue::StepDefinition` object (described above) corresponding to the step
+- `#text_length`: The number of characters in the step text
 
 #### test_step_started
 The `test_step_started` event is fired just before each `Cucumber::Core::Test::Step` is started. It has one attribute:
 * `test_step`: The `Cucumber::Core::Test::Step` object that has just started. This object responds to the following
   methods that may be useful for the purposes of your formatter:
-    - `#action_location`: The feature file in which the step appears and the location of its scenario within that file,
+- `#action_location`: The feature file in which the step appears and the location of its scenario within that file,
       in the form `features/file.feature:line`
-    - `#location`: The feature file in which the step appears and the location of the step within that file, in the same
+- `#location`: The feature file in which the step appears and the location of the step within that file, in the same
       form as described under `#action_location`
-    - `#source`: The Gherkin source of the feature file in which the step appears, without keywords
-    - `#text`: The text of the step, without the Gherkin keyword
+- `#source`: The Gherkin source of the feature file in which the step appears, without keywords
+- `#text`: The text of the step, without the Gherkin keyword
 
 #### test_step_finished
 The `test_step_finished` event is fired after each `Cucumber::Core::Test::Step` has finished running. It has two attributes:


### PR DESCRIPTION
This PR adds docs for writing custom formatters.