### PR TITLE
Spelling fix

### DIFF
--- a/content/guides/10-minute-tutorial.md
+++ b/content/guides/10-minute-tutorial.md
@@ -534,7 +534,7 @@ public void today_is_Sunday() {
 }
 
 @When("^I ask whether it's Friday yet$")
-public void i_ask_whether_is_s_Friday_yet() {
+public void i_ask_whether_it_s_Friday_yet() {
     // Write code here that turns the phrase above into concrete actions
     throw new PendingException();
 }
@@ -681,7 +681,7 @@ Feature: Is it Friday yet?
 	at hellocucumber.Stepdefs.today_is_Sunday(Stepdefs.java:12)
 	at ✽.today is Sunday(hellocucumber/is_it_friday_yet.feature:5)
 
-    When I ask whether it's Friday yet # Stepdefs.i_ask_whether_is_s_Friday_yet()
+    When I ask whether it's Friday yet # Stepdefs.i_ask_whether_it_s_Friday_yet()
     Then I should be told "Nope"       # Stepdefs.i_should_be_told(String)
 
 1 Scenarios (1 pending)


### PR DESCRIPTION
It may be worthwhile to also take a look at how the test code generator creates suggested snippets if it was used to create this example. There may be a bug with how it handles the apostrophe character, as it turned "it's" into "is_s".