### PR TITLE
#262: Provide description of Rule keyword/idiom

### DIFF
--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -427,7 +427,6 @@ Cucumber provides a rich API for manipulating tables from within step definition
 See the [Data Table API reference](https://github.com/cucumber/cucumber/tree/master/datatable) reference for
 more details.
 
-
 # Spoken Languages
 
 The language you choose for Gherkin should be the same language your users and

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -333,32 +333,12 @@ You can also use parameters in [multiline step arguments](#step-arguments).
 
 ## Rule
 
-The `Rule` entity is a rather new idiom in Gherkin (since Gherkin v6).
+The `Rule` keyword has been added in Gherkin v6. Note that Gherkin 6 has not yet been incorporated into all implementation of Cucumber.
 Each `Rule` is intended to represent one *business rule* that should be implemented.
-A `Rule` is used to group together several `Example` (aka: `Scenario`) / `Scenario Outline`
+A `Rule` is used to group together several scenarios 
 that belong to this *business rule*. In addition, a `Rule` may contain a `Background` section.
 
-Rule parent:
-
-- `Feature` (cardinality: one)
-
-Rule children:
-
-- `Description` (cardinality: optional, `0 .. 1`)
-- `Background` (cardinality: optional, `0 .. 1`)
-- `Example`/`Scenario` (cardinality: many, `0 .. N`)
-- `Scenario Outline`/`Scenario Template` (cardinality: many, `0 .. N`)
-
-Rule constraints:
-
-- A `Rule` should have at least one child (that is neither `Description` nor `Background`).
-
-Rule supports:
-
-- `Tags`: Allows to select a `Rule`(s) as part of a runnable set for a test runner.
-- Grouping: Of `Example`/`Scenario`, `Scenario Outline` (and `Background`)
-
-Example:
+For example:
 
 ```gherkin
 # -- FILE: features/gherkin.rule_example.feature

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -39,12 +39,12 @@ Each line that isn't a blank line has to start with a Gherkin *keyword*, followe
 The primary keywords are:
 
 - `Feature`
+- `Rule`
 - `Example` (or `Scenario`)
 - `Given`, `When`, `Then`, `And`, `But`  (steps)
 - `Background`
 - `Scenario Outline` (or `Scenario Template`)
 - `Examples`
-- `Rule`
 
 There are a few secondary keywords as well:
 

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -39,7 +39,7 @@ Each line that isn't a blank line has to start with a Gherkin *keyword*, followe
 The primary keywords are:
 
 - `Feature`
-- `Rule`
+- `Rule` (as of Gherkin 6)
 - `Example` (or `Scenario`)
 - `Given`, `When`, `Then`, `And`, `But`  (steps)
 - `Background`

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -95,6 +95,41 @@ Free-form descriptions (as described above for `Feature`) can also be placed und
 
 You can write anything you like, as long as no line starts with a keyword.
 
+## Rule
+
+The `Rule` keyword has been added in Gherkin v6. (Note that Gherkin 6 has not yet been incorporated into all implementation of Cucumber!)
+The purpose of the `Rule` keyword is to represent one *business rule* that should be implemented.
+It provides additional information for a feature. 
+A `Rule` is used to group together several scenarios 
+that belong to this *business rule*. A `Rule` may contain a `Background` section, and should contain one or more scenarios that illustrate the particular rule.
+
+For example:
+
+```gherkin
+# -- FILE: features/gherkin.rule_example.feature
+Feature: Highlander
+
+  Rule: There can be only One
+
+    Background:
+      Given there are 3 ninjas
+
+    Example: Only One -- More than one alive
+      Given there are more than one ninjas alive
+      When 2 ninjas meet, they will fight
+      Then one ninja dies (but not me)
+      And there is one ninja less alive
+
+    Example: Only One -- One alive
+      Given there is only 1 ninja alive
+      Then he (or she) will live forever ;-)
+
+  Rule: There can be Two (in some cases)
+
+    Example: Two -- Dead and Reborn as Phoenix
+      ...
+```
+
 ## Example
 
 This is a *concrete example* that *illustrates* a business rule. It consists of
@@ -330,41 +365,6 @@ Cucumber will replace these parameters with values from the table *before* it tr
 to match the step against a step definition.
 
 You can also use parameters in [multiline step arguments](#step-arguments).
-
-## Rule
-
-The `Rule` keyword has been added in Gherkin v6. Note that Gherkin 6 has not yet been incorporated into all implementation of Cucumber.
-The purpose of the `Rule` keyword is to represent one *business rule* that should be implemented.
-It provides additional information for a feature. 
-A `Rule` is used to group together several scenarios 
-that belong to this *business rule*. A `Rule` may contain a `Background` section, and should contain one or more scenarios that illustrate the particular rule.
-
-For example:
-
-```gherkin
-# -- FILE: features/gherkin.rule_example.feature
-Feature: Highlander
-
-  Rule: There can be only One
-
-    Background:
-      Given there are 3 ninjas
-
-    Example: Only One -- More than one alive
-      Given there are more than one ninjas alive
-      When 2 ninjas meet, they will fight
-      Then one ninja dies (but not me)
-      And there is one ninja less alive
-
-    Example: Only One -- One alive
-      Given there is only 1 ninja alive
-      Then he (or she) will live forever ;-)
-
-  Rule: There can be Two (in some cases)
-
-    Example: Two -- Dead and Reborn as Phoenix
-      ...
-```
 
 # Step Arguments
 

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -44,6 +44,7 @@ The primary keywords are:
 - `Background`
 - `Scenario Outline` (or `Scenario Template`)
 - `Examples`
+- `Rule`
 
 There are a few secondary keywords as well:
 
@@ -82,7 +83,7 @@ The name and the optional description have no special meaning to Cucumber. Their
 a place for you to document important aspects of the feature, such as a brief explanation
 and a list of business rules (general acceptance criteria).
 
-The free format description for `Feature` ends when you start a line with the keyword `Scenario` or `Scenario Outline`.
+The free format description for `Feature` ends when you start a line with the keyword `Rule`, `Example` or `Scenario Outline` (or their alias keywords).
 
 You can place [tags](/cucumber/api/#tags) above `Feature` to group related features,
 independent of your file and directory structure.
@@ -90,7 +91,7 @@ independent of your file and directory structure.
 ## Descriptions
 
 Free-form descriptions (as described above for `Feature`) can also be placed underneath
-`Example`, `Background`, `Scenario` and `Scenario Outline`.
+`Example`/`Scenario`, `Background`, `Scenario Outline` and `Rule`.
 
 You can write anything you like, as long as no line starts with a keyword.
 
@@ -330,6 +331,60 @@ to match the step against a step definition.
 
 You can also use parameters in [multiline step arguments](#step-arguments).
 
+## Rule
+
+The `Rule` entity is a rather new idiom in Gherkin (since Gherkin v6).
+Each `Rule` is intended to represent one *business rule* that should be implemented.
+A `Rule` is used to group together several `Example` (aka: `Scenario`) / `Scenario Outline`
+that belong to this *business rule*. In addition, a `Rule` may contain a `Background` section.
+
+Rule parent:
+
+- `Feature` (cardinality: one)
+
+Rule children:
+
+- `Description` (cardinality: optional, `0 .. 1`)
+- `Background` (cardinality: optional, `0 .. 1`)
+- `Example`/`Scenario` (cardinality: many, `0 .. N`)
+- `Scenario Outline`/`Scenario Template` (cardinality: many, `0 .. N`)
+
+Rule constraints:
+
+- A `Rule` should have at least one child (that is neither `Description` nor `Background`).
+
+Rule supports:
+
+- `Tags`: Allows to select a `Rule`(s) as part of a runnable set for a test runner.
+- Grouping: Of `Example`/`Scenario`, `Scenario Outline` (and `Background`)
+
+Example:
+
+```gherkin
+# -- FILE: features/gherkin.rule_example.feature
+Feature: Highlander
+
+  Rule: There can be only One
+
+    Background:
+      Given there are 3 ninjas
+
+    Example: Only One -- More than one alive
+      Given there are more than one ninjas alive
+      When 2 ninjas meet, they will fight
+      Then one ninja dies (but not me)
+      And there is one ninja less alive
+
+    Example: Only One -- One alive
+      Given there is only 1 ninja alive
+      Then he (or she) will live forever ;-)
+
+  Rule: There can be Two (in some cases)
+
+    Example: Two -- Dead and Reborn as Phoenix
+      ...
+```
+
 # Step Arguments
 
 In some cases you might want to pass more data to a step than fits on a single line.
@@ -371,6 +426,7 @@ Just like `Doc Strings`, `Data Tables` will be passed to the step definition as 
 Cucumber provides a rich API for manipulating tables from within step definitions.
 See the [Data Table API reference](https://github.com/cucumber/cucumber/tree/master/datatable) reference for
 more details.
+
 
 # Spoken Languages
 

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -334,9 +334,10 @@ You can also use parameters in [multiline step arguments](#step-arguments).
 ## Rule
 
 The `Rule` keyword has been added in Gherkin v6. Note that Gherkin 6 has not yet been incorporated into all implementation of Cucumber.
-Each `Rule` is intended to represent one *business rule* that should be implemented.
+The purpose of the `Rule` keyword is to represent one *business rule* that should be implemented.
+It provides additional information for a feature. 
 A `Rule` is used to group together several scenarios 
-that belong to this *business rule*. In addition, a `Rule` may contain a `Background` section.
+that belong to this *business rule*. A `Rule` may contain a `Background` section, and one or more scenarios.
 
 For example:
 

--- a/content/gherkin/reference.md
+++ b/content/gherkin/reference.md
@@ -337,7 +337,7 @@ The `Rule` keyword has been added in Gherkin v6. Note that Gherkin 6 has not yet
 The purpose of the `Rule` keyword is to represent one *business rule* that should be implemented.
 It provides additional information for a feature. 
 A `Rule` is used to group together several scenarios 
-that belong to this *business rule*. A `Rule` may contain a `Background` section, and one or more scenarios.
+that belong to this *business rule*. A `Rule` may contain a `Background` section, and should contain one or more scenarios that illustrate the particular rule.
 
 For example:
 


### PR DESCRIPTION
Provides the description for the `Rule` keyword / idiom, up to now missing in the Gherkin reference documentation. The `Rule` keyword is supported since Gherkin v6.
