### PR TITLE
API: Add parameter list to the example showing Java's "after" hook in the annotated method style

### DIFF
--- a/content/cucumber/api.md
+++ b/content/cucumber/api.md
@@ -432,7 +432,7 @@ Before({tags: '@browser and not @headless'}, function () {
 
 {{% block "ruby" %}}
 ```ruby
-Before('@browser and not @headless' do
+Before('@browser and not @headless') do
 end
 ```
 {{% /block %}}

--- a/content/cucumber/api.md
+++ b/content/cucumber/api.md
@@ -411,7 +411,7 @@ Annotated method style:
 
 ```java
 @After("@browser and not @headless")
-public void doSomethingAfter(){
+public void doSomethingAfter(Scenario scenario){
 }
 ```
 


### PR DESCRIPTION
Small mistake I guess