### PR TITLE
Add Api automation tools (for Java mainly)

### DIFF
--- a/content/community/not-cucumber.md
+++ b/content/community/not-cucumber.md
@@ -62,3 +62,18 @@ More information on [Capybara](http://teamcapybara.github.io/capybara/).
 
 {{% text "java,javascript" %}}Capybara only works with Ruby.{{% /text %}}
 
+# API automation
+
+## RestAssured
+RestAssured is an API automation tool for Java.
+
+{{% block "java" %}}
+For more information see the [official website](http://rest-assured.io/).
+{{% /block %}}
+
+## Karate
+Karate is an API automation tool for Java.
+
+{{% block "java" %}}
+For more information see the [Karate project on GitHub](https://github.com/intuit/karate).
+{{% /block %}}

--- a/content/guides/api-automation.md
+++ b/content/guides/api-automation.md
@@ -1,0 +1,30 @@
+---
+title: API Automation
+subtitle: RestAssured, Karate and more
+polyglot:
+  - java
+  - javascript
+  - ruby
+  - kotlin
+weight: 1350
+---
+
+Cucumber is not an API automation tool, but it works well with the following API automation tools.
+
+Using API's for your automation, can make your tests faster and less flaky than going through the UI.
+In general, API's change less frequently than the UI; keeping your automation up to date for longer.
+
+# RestAssured
+RestAssured is an API automation tool for Java.
+
+{{% block "java" %}}
+You can use RestAssured in your step definitions to make API calls and verify responses.
+For more information see the [official website](http://rest-assured.io/).
+{{% /block %}}
+
+# Karate
+Karate is an API automation tool for Java.
+
+{{% block "java" %}}
+For more information see the [Karate project on GitHub](https://github.com/intuit/karate).
+{{% /block %}}


### PR DESCRIPTION
Add API automation page, including 2 Java tools and 1 Ruby tool.
Partial fix for #276

Also adds RubyMine as a Ruby/Rails IDE.

I'd be happy to take suggestions for additional tools (especially for Ruby and JavaScript) and add them; this should not be blocking for merging this PR imho.