### PR TITLE
Add semver/upgrading info.

### DIFF
--- a/content/community/faq.md
+++ b/content/community/faq.md
@@ -50,6 +50,18 @@ Note that with Cucumber-JVM v2.x, the `groupId` has changed from `info.cukes` to
 If you cannot find a version newer than 1.2.5, change the groupId in your dependencies.
 {{% /block %}}
 
+## Upgrading
+Cucumber tries to follow the [SemVer](http://semver.org/) specification for release numbers. Essentially, that means that:
+
+* If only the right-hand (patch) number in the release changes, you don't need to worry.
+* If the middle number (minor) number in the release changes, you don't need to worry.
+* If the left-hand (major) number changes, you can expect that things might break.
+
+You can read the [history file](https://github.com/cucumber/cucumber/blob/master/History.md) to learn about the changes in every release.
+
+Implementations of Cucumber in a particular language, should have a `CHANGELOG.md`, describing the changed made per version.
+
+
 ## How do I run Cucumber?
 For information on how to run Cucumber, see [Running Cucumber](/cucumber/api/#running-cucumber).
 

--- a/content/community/faq.md
+++ b/content/community/faq.md
@@ -59,7 +59,7 @@ Cucumber tries to follow the [SemVer](http://semver.org/) specification for rele
 
 You can read the [history file](https://github.com/cucumber/cucumber/blob/master/History.md) to learn about the changes in every release.
 
-Implementations of Cucumber in a particular language, should have a `CHANGELOG.md`, describing the changed made per version.
+Implementations of Cucumber in a particular language, should have a `CHANGELOG.md`, describing the changes made per version.
 
 
 ## How do I run Cucumber?


### PR DESCRIPTION
Add info from https://github.com/cucumber/cucumber/wiki/Upgrading, so that page can be removed (as mentioned in #144). 
Not sure where in the docs would be a proper place (suggestions welcome). This could be improved in #142 - Migration guides could be a separate page.
In the mean time let's at least add it to the FAQ page.