### PR TITLE
More idiomatic Kotlin in examples plus fixed compilation error

### DIFF
--- a/content/guides/10-minute-tutorial.md
+++ b/content/guides/10-minute-tutorial.md
@@ -254,8 +254,7 @@ import org.junit.runner.RunWith
 
 @RunWith(Cucumber::class)
 @CucumberOptions(plugin = ["pretty"])
-class RunCucumberTest {
-}
+class RunCucumberTest
 ```
 
 * Now you can delete the `RunCucumberTest.java` class.
@@ -285,12 +284,9 @@ import org.junit.runner.RunWith
 
 @RunWith(Cucumber::class)
 @CucumberOptions(plugin = ["pretty"])
-class RunCucumberTest {
-}
+class RunCucumberTest
 ```
 
-* Now delete the `RunCucumberTest.java` class (or even the whole `java` directory).
-* Finally, create a Kotlin class called `StepDefs` inside the `hellocucumber` package.
 
 {{% /block %}}
 
@@ -862,8 +858,8 @@ fun isItFriday(today: String) = ""
 
 
 class StepDefs {
-    lateinit var today: String
-    lateinit var actualAnswer: String
+    private lateinit var today: String
+    private lateinit var actualAnswer: String
 
     @Given("^today is Sunday$")
     fun today_is_Sunday() {
@@ -1479,8 +1475,8 @@ fun isItFriday(today: String) = if (today == "Friday") "TGIF" else "Nope"
 
 
 class StepDefs {
-    lateinit var today: String
-    lateinit var actualAnswer: String
+    private lateinit var today: String
+    private lateinit var actualAnswer: String
 
     @Given("^today is \"([^\"]*)\"$")
     fun today_is(today: String) {

--- a/content/guides/10-minute-tutorial.md
+++ b/content/guides/10-minute-tutorial.md
@@ -1480,7 +1480,7 @@ class StepDefs {
 
     @Given("^today is \"([^\"]*)\"$")
     fun today_is(today: String) {
-        today = today
+        this.today = today
     }
 
     @When("^I ask whether it's Friday yet$")


### PR DESCRIPTION
1. When a class is empty the open and close curly braces are not mandatory.
2. Compared to the java example, the properties of StepDefs should also be private.
3. I think the deleted lines were redundant.
4. Fixed compilation error with "this" qualifier.
(Test function names can be more readable, e.g. `I should be told` instead of i_should_be_told, but maybe modifying the generated code is not advised for this example)