### PR TITLE
FAQ: Add Arity mismatch exception explanation (see #284)

### DIFF
--- a/content/community/faq.md
+++ b/content/community/faq.md
@@ -223,4 +223,4 @@ Otherwise, Picocontainer is the most light weight framework you can use.
 {{% /block %}}
 
 # Arity Mismatch
-An Arity mismatch exception{{% text "java,kotlin" %}}, `cucumber.runtime.CucumberException: Arity mismatch`,{{% /text %}} indicates that the step does not provide the right number of arguments needed for the step definition.
+An Arity mismatch exception{{% text "java,kotlin" %}}- `cucumber.runtime.CucumberException: Arity mismatch`-{{% /text %}} indicates that the step does not provide the right number of arguments needed for the step definition.

--- a/content/community/faq.md
+++ b/content/community/faq.md
@@ -221,3 +221,6 @@ If you are using Cucumber on the JVM, you can use [dependency injection (DI)](/c
 If your project already uses a dependency framework supported by Cucumber (and/or you are familiar with one of them), it's probably easiest to use that framework. 
 Otherwise, Picocontainer is the most light weight framework you can use.
 {{% /block %}}
+
+# Arity Mismatch
+```cucumber.runtime.CucumberException: Arity mismatch``` indicates that the step does not provide the arguments needed for the step definition.

--- a/content/community/faq.md
+++ b/content/community/faq.md
@@ -223,4 +223,4 @@ Otherwise, Picocontainer is the most light weight framework you can use.
 {{% /block %}}
 
 # Arity Mismatch
-```cucumber.runtime.CucumberException: Arity mismatch``` indicates that the step does not provide the arguments needed for the step definition.
+An Arity mismatch exception{{% text "java,kotlin" %}}, `cucumber.runtime.CucumberException: Arity mismatch`,{{% /text %}} indicates that the step does not provide the right number of arguments needed for the step definition.

--- a/content/community/faq.md
+++ b/content/community/faq.md
@@ -223,4 +223,4 @@ Otherwise, Picocontainer is the most light weight framework you can use.
 {{% /block %}}
 
 # Arity Mismatch
-An Arity mismatch exception{{% text "java,kotlin" %}} `cucumber.runtime.CucumberException: Arity mismatch`{{% /text %}} indicates that the step does not provide the right number of arguments needed for the step definition.
+An arity mismatch exception{{% text "java,kotlin" %}} `cucumber.runtime.CucumberException: Arity mismatch`{{% /text %}} indicates that the step does not provide the right number of arguments needed for the step definition.

--- a/content/community/faq.md
+++ b/content/community/faq.md
@@ -223,4 +223,4 @@ Otherwise, Picocontainer is the most light weight framework you can use.
 {{% /block %}}
 
 # Arity Mismatch
-An Arity mismatch exception{{% text "java,kotlin" %}}- `cucumber.runtime.CucumberException: Arity mismatch`-{{% /text %}} indicates that the step does not provide the right number of arguments needed for the step definition.
+An Arity mismatch exception{{% text "java,kotlin" %}} `cucumber.runtime.CucumberException: Arity mismatch`{{% /text %}} indicates that the step does not provide the right number of arguments needed for the step definition.


### PR DESCRIPTION
Added to the bottom of the FAQ page a clause indicating what is the meaning of Arity mismatch.

Fixes part of the issues related to #284 