### PR TITLE
Update java.md to reflect recommended way of adding a Gradle dependency and task

### DIFF
--- a/content/tools/java.md
+++ b/content/tools/java.md
@@ -67,7 +67,7 @@ Steps:
     }
     ```
 
-    For Gradle **5.0 or **, you can add the following dependency block to `build.gradle`.
+    For Gradle **5.0 or more recent**, you can add the following dependency block to `build.gradle`.
     ```
     dependencies {
         testImplementation 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'

--- a/content/tools/java.md
+++ b/content/tools/java.md
@@ -60,19 +60,34 @@ To run Cucumber with [Gradle](https://gradle.org/), make sure that:
 Steps:
 
 1.  Create a new Gradle project or look at [java-gradle](https://github.com/cucumber/cucumber-jvm/tree/master/examples/java-gradle) example on Github
-2.  Add the following dependency to `build.gradle`
-
+2.  Add the appropriate dependency to `build.gradle`, based on the Gradle version being used.
+    #### Gradle version 4.10.3 or older
     ```
     dependencies {
         testCompile 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
     }
     ```
-3. Add the following configuration to `build.gradle`
+    #### Gradle version 5.0 or newer
+    ```
+    dependencies {
+        testImplementation 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
+    }
+    ```
 
+3. Add the appropriate configuration to `build.gradle`, based on the Gradle version being used.
+    #### Gradle version 4.10.3 or older
     ```
     configurations {
         cucumberRuntime {
             extendsFrom testRuntime
+        }
+    }
+    ```
+    #### Gradle version 5.0 or newer
+    ```
+    configurations {
+        cucumberRuntime {
+            extendsFrom testImplementation
         }
     }
     ```

--- a/content/tools/java.md
+++ b/content/tools/java.md
@@ -60,22 +60,21 @@ To run Cucumber with [Gradle](https://gradle.org/), make sure that:
 Steps:
 
 1.  Create a new Gradle project or look at [java-gradle](https://github.com/cucumber/cucumber-jvm/tree/master/examples/java-gradle) example on Github
-2.  Add the appropriate dependency to `build.gradle`, based on the Gradle version being used.
-    ### Gradle version 4.10.3 or older
+2.  If you are going to use Gradle **4.10.3 or older**, add this dependency block to `build.gradle`.
     ```
     dependencies {
         testCompile 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
     }
     ```
-    ### Gradle version 5.0 or newer
+
+    For Gradle **5.0 or **, you can add the following dependency block to `build.gradle`.
     ```
     dependencies {
         testImplementation 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
     }
     ```
 
-3. Add the appropriate configuration to `build.gradle`, based on the Gradle version being used.
-    ### Gradle version 4.10.3 or older
+3. For Gradle **4.10.3 or older**, add the following configuration to `build.gradle`.
     ```
     configurations {
         cucumberRuntime {
@@ -83,7 +82,7 @@ Steps:
         }
     }
     ```
-    ### Gradle version 5.0 or newer
+    For Gradle **5.0 or more recent**, the following configuration must be added to `build.gradle`.
     ```
     configurations {
         cucumberRuntime {

--- a/content/tools/java.md
+++ b/content/tools/java.md
@@ -61,13 +61,13 @@ Steps:
 
 1.  Create a new Gradle project or look at [java-gradle](https://github.com/cucumber/cucumber-jvm/tree/master/examples/java-gradle) example on Github
 2.  Add the appropriate dependency to `build.gradle`, based on the Gradle version being used.
-    #### Gradle version 4.10.3 or older
+    ### Gradle version 4.10.3 or older
     ```
     dependencies {
         testCompile 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
     }
     ```
-    #### Gradle version 5.0 or newer
+    ### Gradle version 5.0 or newer
     ```
     dependencies {
         testImplementation 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
@@ -75,7 +75,7 @@ Steps:
     ```
 
 3. Add the appropriate configuration to `build.gradle`, based on the Gradle version being used.
-    #### Gradle version 4.10.3 or older
+    ### Gradle version 4.10.3 or older
     ```
     configurations {
         cucumberRuntime {
@@ -83,7 +83,7 @@ Steps:
         }
     }
     ```
-    #### Gradle version 5.0 or newer
+    ### Gradle version 5.0 or newer
     ```
     configurations {
         cucumberRuntime {


### PR DESCRIPTION
Existing code snippets no longer work with Gradle 5, as `testRuntime` has been deprecated. Updating the documentation to reflect the recommended way of doing things.