### PR TITLE
Update not-cucumber.md

### DIFF
--- a/content/community/not-cucumber.md
+++ b/content/community/not-cucumber.md
@@ -24,7 +24,7 @@ If not, you can create an issue yourself.
 {{% /block %}}
 
 ## Eclipse
-{{% text "javascript,ruby" %}}IntelliJ is a Java IDE.{{% /text %}}
+{{% text "javascript,ruby" %}}Eclipse is a Java IDE.{{% /text %}}
 {{% block "java,kotlin" %}}
 You can find the [Cucumber Eclipse Plugin on GitHub](https://github.com/cucumber/cucumber-eclipse). It is an open source plugin.
 {{% /block %}}


### PR DESCRIPTION
Seems both IntelliJ and Eclipse sections had 'IntelliJ is a Java IDE' in non java tabs, so i just fixed that.