### PR TITLE
Remove Cucumber Pro documentation (Fixes #309)

### DIFF
--- a/content/cucumber/reporting.md
+++ b/content/cucumber/reporting.md
@@ -1,6 +1,6 @@
 ---
 title: Reporting
-subtitle: "Built-in reporter plugins, Cucumber Pro, Third-party plugins"
+subtitle: "Built-in reporter plugins, Custom formatters, Third-party plugins"
 polyglot:
 - java
 - javascript
@@ -15,7 +15,7 @@ what scenarios have passed or failed.
 Some plugins are built-in, others have to be installed separately. You can also
 build your own.
 
-This page documents built-in formatter plugins, the Cucumber Pro plugin, and some common third-party plugins.
+This page documents built-in formatter plugins, custom formatters and some common third-party plugins.
 Available plugins may vary per programming language.
 
 # Built-in reporter plugins
@@ -28,234 +28,6 @@ There are several reporter plugins built into Cucumber:
 * `json`
 * `rerun`
 * `junit`
-
-# Cucumber Pro plugin
-
-This {{% text "java,kotlin,javascript,ruby" %}}Cucumber{{% /text %}}{{% text "dotnet" %}}SpecFlow{{% /text %}} plugin publishes
-results to [Cucumber Pro](https://cucumber.io/pro).
-
-## Requirements
-
-Your project must be stored in a Git repository, and you must be using one of the
-following CI servers:
-
-* [Bamboo](https://www.atlassian.com/software/bamboo)
-* [Circle CI](https://circleci.com/)
-* [Jenkins](https://jenkins.io/)
-* [Team Foundation Server (TFS)](https://www.visualstudio.com/tfs/)
-* [Travis CI](https://travis-ci.org/)
-* [Wercker](http://www.wercker.com/)
-
-## Installation
-
-{{% block "java,kotlin" %}}
-Add the following dependency to your `pom.xml`:
-
-```xml
-<dependency>
-    <groupId>io.cucumber</groupId>
-    <artifactId>pro-plugin</artifactId>
-    <version>{{% version "propluginjvm" %}}</version>
-    <scope>test</scope>
-</dependency>
-```
-
-(If you're using Gradle or a different build system, declare a similar dependency).
-
-Enable the plugin in the JUnit class you use to run Cucumber:
-
-```java
-@RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"io.cucumber.pro.JsonReporter:default"})
-public class RunCucumberTest {
-}
-```
-
-```kotlin
-@RunWith(Cucumber::class)
-@CucumberOptions(plugin = ["io.cucumber.pro.JsonReporter:default"])
-class RunCucumberTest
-```
-
-If you're on Cucumber-JVM 1.2.5 or older, use `io.cucumber.pro.JsonReporter12:default`
-instead of `io.cucumber.pro.JsonReporter:default`.
-
-{{% /block %}}
-
-{{% block "dotnet" %}}
-Use NuGet to install the plugin into your SpecFlow project:
-
-```shell
-PM> Install-Package Cucumber.Pro.SpecFlowPlugin
-```
-{{% /block %}}
-
-## Configuration
-
-Create a file called `cucumber.yml` in the root directory of your git repository with
-the following contents (replace `***` with actual values).
-
-```yaml
-cucumberpro:
-  # The name of the Cucumber Pro project.
-  # You can leave this blank if your Cucumber Pro project name is identical to the
-  # CI project name, and you you're using one of Bamboo, Circle CI, TFS, Travis
-  # or Wercker.
-  projectname: ***
-  # The URL of the Cucumber Pro server.
-  # You can leave this blank if you are publishing to https://app.cucumber.pro/
-  url: ***
-```
-
-## Authentication
-
-If you are publishing to https://app.cucumber.pro/ you also have to define
-an environment variable named `CUCUMBERPRO_TOKEN` in your CI project. The value
-should be your Cucumber Pro project's API token, avaiable from the project
-settings page. Consult your CI server's documentation for details about how
-to define environment variables.
-
-Authentication is not required on a privately hosted Cucumber Pro Appliance.
-
-## Activation
-
-The plugin will activate itself automatically if it detects that it's running
-in one of the supported CI environments. When you run {{% text "java,kotlin,javascript,ruby" %}}Cucumber{{% /text %}}{{% text "dotnet" %}}SpecFlow{{% /text %}} from your workstation the plugin will **not**
-be activated, and will not publish results.
-
-When you configure the plugin for the first time you can force-activate the plugin
-from your work station by defining the following environment variables:
-
-* `GIT_COMMIT` - you can find it by running `git rev-parse HEAD`
-* `GIT_BRANCH` - you can find it by running `git rev-parse --abbrev-ref HEAD`
-
-This is useful for verifying that you have configured the plugin correctly.
-
-## Profiles
-
-If you run {{% text "java,kotlin,javascript,ruby" %}}Cucumber{{% /text %}}{{% text "dotnet" %}}SpecFlow{{% /text %}}
-several times as part of your build (with different options,
-perhaps different tags), you can specify a different *profile name* for each run.
-This allows Cucumber Pro to show separate results for each profile.
-
-The profile name can be specified in the `CUCUMBERPRO_PROFILE` environment variable,
-which you would typically define in a wrapper script that launches
-{{% text "java,kotlin,javascript,ruby" %}}Cucumber{{% /text %}}{{% text "dotnet" %}}SpecFlow{{% /text %}}.
-
-{{% block "java,kotlin" %}}
-The profile name can also be specified by appending a colon and a profile name to the
-plugin class name:
-
-```java
-@RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"io.cucumber.pro.JsonReporter:smoke"}, tags = "@ui and @smoke")
-public class RunCucumberTest {
-}
-```
-
-```kotlin
-@RunWith(Cucumber::class)
-@CucumberOptions(plugin = ["io.cucumber.pro.JsonReporter:smoke"], tags = ["@ui and @smoke"])
-class RunCucumberTest
-```
-
-```java
-@RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"io.cucumber.pro.JsonReporter:default"}, tags = "not @ui and not @smoke")
-public class RunCucumberTest {
-}
-```
-
-```kotlin
-@RunWith(Cucumber::class)
-@CucumberOptions(plugin = ["io.cucumber.pro.JsonReporter:default"], tags = ["not @ui and not @smoke"])
-class RunCucumberTest
-```
-
-{{% /block %}}
-
-## Advanced configuration
-
-The `cucumber.yml` configuration file has more options that can be overridden for
-finer grained control. The defaults are as follows:
-
-```yaml
-cucumberpro:
-  # The name of the Cucumber Pro project.
-  projectname:
-
-  # The project-specific authentication token. You can find it in the project settings (press `?` to display it).
-  #
-  # Rather than defining the value in this file we recommend defining the `CUCUMBERPRO_TOKEN` environment variable
-  # in your CI server.
-  #
-  # Consult your CI server's documentation for details about defining per-project environment variables.
-  # Some CI servers such as Travis and Circle CI allow you to define environment variables in a file checked into git.
-  # *DO NOT DO THIS* - as it would allow anyone with read acceess to your repository to publish results.
-  token:
-
-  # The plugin sends your local environment variables to Cucumber Pro so it can detect the CI build number,
-  # git branch/tag and other information about the build. This mask is a regular expression for filtering
-  # out sensitive values that should not be sent to Cucumber Pro.
-  envmask: SECRET|KEY|TOKEN|PASSWORD|PWD
-
-  # Sets the log level to one of `DEBUG`, `INFO`, `WARN`, `ERROR` or `FATAL`. Defaults to `WARN`.
-  # Setting it to `DEBUG` will also print the current configuration when the plugin runs.
-  logging: INFO
-
-  # Writes out the log messages to the specified file. Useful for debugging.
-  logfile:
-
-  # Override this if you are using a privately hosted Cucumber Pro Appliance.
-  # We recommend setting this with a CUCUMBERPRO_URL environment variable defined globally on your build server.
-  url: https://app.cucumber.pro/
-
-  connection:
-    # Set this to false if you want the build to break in case Cucumber Pro is unavailable.
-    ignoreerror: true
-
-    # If the http connection for publishing results takes longer than this (milliseconds),
-    # time out the connection.
-    timeout: 5000
-```
-
-You can make some of the settings global by creating a file with global settings.
-The plugin will load the configuration in all the following files (if they exist):
-
-{{% block "java,kotlin" %}}
-* `/usr/local/etc/cucumber/cucumber.yml`
-* `~/.cucumber/cucumber.yml`
-* `~/cucumber.yml`
-* `./cucumber.yml` (relative to the git root)
-* `./.cucumber/cucumber.yml` (relative to the git root)
-{{% /block %}}
-
-{{% block "dotnet" %}}
-* `C:\cucumber\cucumber.yml`
-* `My Documents\.cucumber\cucumber.yml`
-* `My Documents\cucumber.yml`
-* `cucumber.yml` (relative to the git root)
-* `.cucumber\cucumber.yml` (relative to the git root)
-{{% /block %}}
-
-Every setting can also be overridden with environment variables. For example, if you want
-the plugin to log more verbosely:
-
-```
-# Linux / MacOS
-export CUCUMBERPRO_LOGGING=DEBUG
-
-# Windows
-SET CUCUMBERPRO_LOGGING=DEBUG
-```
-
-{{% block "java,kotlin" %}}
-Alternatively, you can specify a Java system property (in Maven, Gradle or other build tool):
-
-```
--Dcucumberpro.logging=DEBUG
-```
-{{% /block %}}
 
 # Custom formatters
 The Cucumber formatter API is readily extensible. A formatter can be any class implementing the event-based formatter
@@ -293,7 +65,7 @@ end
 {{% /block %}}
 
 ### Configuration object
-The formatter initializer is passed a {{% text "java,dotnet" %}}Cucumber configuration{{% /text %}}{{% text "ruby" %}}`Cucumber::Configuration`{{% /text %}} object. This is the
+The formatter initializer is passed a {{% text "java,javascript,kotlin,dotnet" %}}Cucumber configuration{{% /text %}}{{% text "ruby" %}}`Cucumber::Configuration`{{% /text %}} object. This is the
 [configuration for the test run](https://docs.cucumber.io/cucumber/configuration/),
 including default configurations and [options](https://docs.cucumber.io/cucumber/api/) passed in at the command line.
 It can be useful to access these options, so that your formatter can modify its behavior in response to user directives.


### PR DESCRIPTION
As discussed in #309 and at Cukenfest, Jam is not part of Cucumber and should not be documented as part of the Cucumber documentation. Therefore, it was removed.

In addition, a small fix for the polyglot tabs.