### PR TITLE
Add navigation to docs (not homepage)

### DIFF
--- a/JSNOTES.md
+++ b/JSNOTES.md
@@ -1,0 +1,4 @@
+# Notes
+
+* Should be change the link to training under professional services away from https://docs.cucumber.io/professional/training/ and point to training directly like we are with school?
+

--- a/JSNOTES.md
+++ b/JSNOTES.md
@@ -1,4 +1,0 @@
-# Notes
-
-* Should be change the link to training under professional services away from https://docs.cucumber.io/professional/training/ and point to training directly like we are with school?
-

--- a/themes/cucumber-hugo/layouts/partials/head.html
+++ b/themes/cucumber-hugo/layouts/partials/head.html
@@ -10,4 +10,5 @@
   <link rel="stylesheet" href="/css/cucumber.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
   <script src="/js/site.js"></script>
+  <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Slab" rel="stylesheet">
 </head>

--- a/themes/cucumber-hugo/layouts/partials/navbar.html
+++ b/themes/cucumber-hugo/layouts/partials/navbar.html
@@ -13,16 +13,53 @@
 
   <div class="navbar-menu" id="navbarMenu">
     <div class="navbar-end">
-      <a class="navbar-item" href="https://github.com/cucumber/cucumber">
-        <span class="icon">
-          <i class="fab fa-github"></i>
-        </span>
-      </a>
-      <a class="navbar-item" href="https://twitter.com/cucumberbdd">
-        <span class="icon">
-          <i class="fab fa-twitter"></i>
-        </span>
-      </a>
+        <a class="navbar-item" href="https://cucumber.io/">
+          <span>
+            home
+          </span>
+        </a>
+        <a class="navbar-item" href="https://cucumber.io/jam">
+          <span>
+            jam
+          </span>
+        </a>
+        <a class="navbar-item" href="https://cucumber.io/blog">
+          <span>
+            blog
+          </span>
+        </a>
+        <a class="navbar-item" href="https://cucumber.io/events">
+          <span>
+            events
+          </span>
+        </a>
+        <a class="navbar-item" href="https://cucumber.io/docs">
+          <span>
+            documentation
+          </span>
+        </a>
+    </div>
+    <div class="navbar-end-2">
+        <a class="navbar-item" href="https://cucumber.io/training">
+          <span>
+            learn bdd
+          </span>
+        </a>
+        <a class="navbar-item" href="https://cucumber.io/school">
+          <span>
+            video tutorials
+          </span>
+        </a>
+        <a class="navbar-item" href="https://github.com/cucumber">
+          <span>
+            open source
+          </span>
+        </a>
+        <a class="navbar-item" href="https://cucumber.io/support">
+          <span>
+            support
+          </span>
+        </a>
     </div>
   </div>
 </nav>

--- a/themes/cucumber-hugo/static/css/cucumber.css
+++ b/themes/cucumber-hugo/static/css/cucumber.css
@@ -5982,6 +5982,8 @@ a.dropdown-item.is-active {
   min-height: 3.25rem;
   position: relative;
   z-index: 30;
+  font-family: Roboto, sans-serif;
+  text-transform: uppercase;
 }
 
 .navbar.is-white {

--- a/themes/cucumber-hugo/static/css/cucumber.css
+++ b/themes/cucumber-hugo/static/css/cucumber.css
@@ -6786,12 +6786,16 @@ a.navbar-item:hover, a.navbar-item.is-active,
   .navbar,
   .navbar-menu,
   .navbar-start,
-  .navbar-end {
-    align-items: stretch;
+  .navbar-end,
+  .navbar-end-2 {
+    flex-direction: row;
+    align-items: flex-start;
+    flex-wrap: wrap;
     display: flex;
   }
   .navbar {
     min-height: 3.25rem;
+    justify-content: space-between;
   }
   .navbar.is-spaced {
     padding: 1rem 2rem;
@@ -6858,6 +6862,9 @@ a.navbar-item:hover, a.navbar-item.is-active,
   .navbar-menu {
     flex-grow: 1;
     flex-shrink: 0;
+    height:90px;
+    max-width:600px;
+    justify-content: flex-end;
   }
   .navbar-start {
     justify-content: flex-start;


### PR DESCRIPTION
Trying to prevent Hotel California'ing folks on the docs page from the rest of our site's pages. AKA being unable to easily get to other pages from docs. While I know that there are ways to get to those other pages already in there, this helps make that easier. Mainly, this serves to continue to help hopefully drive traffic to the services pages.(training/school)

Not doing anything fancy, just getting something that's similar to the main page and blog set up. If there are objections, happy to chat about them, let me know!

If there are none in say, a week, I'd like to merge then. Obviously happy to get it in sooner, too!

Here's what it looks like not hamburgered:
![header](https://user-images.githubusercontent.com/21065409/56465047-b55ef480-63aa-11e9-8bca-34e5e6690ad5.png)
And hamburgered:
![hamburgered](https://user-images.githubusercontent.com/21065409/56465052-daebfe00-63aa-11e9-9405-6dc49e8339d1.png)
