### PR TITLE
Removed 'Background' under 'Rule' in ninjas example

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -113,7 +113,7 @@ Feature: Highlander
 
     Example: Only One -- More than one alive
       Given there are 3 ninjas
-      And there are more than one ninjas alive
+      And there are more than one ninja alive
       When 2 ninjas meet, they will fight
       Then one ninja dies (but not me)
       And there is one ninja less alive

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -111,11 +111,9 @@ Feature: Highlander
 
   Rule: There can be only One
 
-    Background:
-      Given there are 3 ninjas
-
     Example: Only One -- More than one alive
-      Given there are more than one ninjas alive
+      Given there are 3 ninjas
+      And there are more than one ninjas alive
       When 2 ninjas meet, they will fight
       Then one ninja dies (but not me)
       And there is one ninja less alive


### PR DESCRIPTION
The ninjas example, which explains 'Rule', has a 'Background' under the 'Rule'.
This is a bug in the docs as a 'Rule' can't have a 'Background' underneath it.

This PR introduces two changes:

## 1. Removed 'Background' and its content under 'Rule'

I've removed the 'Background' under the 'Rule'.

## 2. Refactored the 'Given' statement that was under 'Background'

I've also refactored the 'Given' statement that was introduced by that 'Background'.

When refactoring the 'Given' statement across the two 'Example's, I found that the second example didn't need that 'Given' statement. If I had added "Given there are 3 ninjas" from 'Background' to the second example, it would have read like this:

  Rule: There can be only One

    Example: Only One -- One alive
      Given there are 3 ninjas
      Given there is only 1 ninja alive
      Then he (or she) will live forever ;-)

I believe that the first two Given statements are redundant. So I left the 1st one (which came from 'Background') out.