### PR TITLE
Use consistent tone in overview

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -40,6 +40,8 @@
           <h2 class="subtitle">
             <p>
             <ul>
+            <li>Read the <a href="/docs/guides/overview/">Introduction</a></li>
+
             <li><a href="/docs/installation/">Install Cucumber</a></li>
 
             <li>Try the <a href="/docs/guides/10-minute-tutorial/"> tutorial</a> in Java, JavaScript, Ruby or Kotlin</li>

--- a/content/docs/guides/overview.md
+++ b/content/docs/guides/overview.md
@@ -3,18 +3,14 @@ title: Introduction
 subtitle: New to Cucumber? Start here!
 weight: 1000
 ---
-
-{{% note "Before you get started" %}}
-If you're new to Behaviour-Driven Development (BDD) read our 
-[BDD introduction](/docs/bdd) first.
-{{% /note %}}
-
-Ok, now that you know that BDD is about discovery, collaboration and examples
-(and not testing), let's take a look at Cucumber.
-
 # What is Cucumber?
 
 Cucumber is a tool that supports [Behaviour-Driven Development(BDD)](/docs/bdd).
+If you're new to Behaviour-Driven Development read our [BDD introduction](/docs/bdd)
+first.
+
+Ok, now that you know that BDD is about discovery, collaboration and examples
+(and not testing), let's take a look at Cucumber.
 
 Cucumber reads executable specifications written in plain text and validates
 that the software does what those specifications say. The specifications

--- a/content/docs/guides/overview.md
+++ b/content/docs/guides/overview.md
@@ -5,8 +5,8 @@ weight: 1000
 ---
 
 {{% note "Before you get started" %}}
-If you're new to Behaviour-Driven Development (BDD) (or if you think it's a testing technique 😏) read
-our [BDD introduction](/docs/bdd) first.
+If you're new to Behaviour-Driven Development (BDD) read our 
+[BDD introduction](/docs/bdd) first.
 {{% /note %}}
 
 Ok, now that you know that BDD is about discovery, collaboration and examples
@@ -16,9 +16,9 @@ Ok, now that you know that BDD is about discovery, collaboration and examples
 
 Cucumber is a tool that supports [Behaviour-Driven Development(BDD)](/docs/bdd).
 
-Cucumber reads executable specifications written in plain text and validates that the
-software does what those specifications say. The specifications consists of multiple
-*examples*, or *scenarios*. For example:
+Cucumber reads executable specifications written in plain text and validates
+that the software does what those specifications say. The specifications
+consists of multiple *examples*, or *scenarios*. For example:
 
 ```gherkin
 Scenario: Breaker guesses a word
@@ -27,17 +27,17 @@ Scenario: Breaker guesses a word
   Then the Maker is asked to score
 ```
 
-Each scenario is a list of *steps* for Cucumber to work through. Cucumber verifies
-that the software conforms with the specification and generates a report indicating
-✅ success or ❌ failure for each scenario.
+Each scenario is a list of *steps* for Cucumber to work through. Cucumber
+verifies that the software conforms with the specification and generates a
+report indicating ✅ success or ❌ failure for each scenario.
 
-In order for Cucumber
-to understand the scenarios, they must follow some basic syntax rules, called [Gherkin](/docs/gherkin/).
+In order for Cucumber to understand the scenarios, they must follow some basic
+syntax rules, called [Gherkin](/docs/gherkin/).
 
 # What is Gherkin?
 
-Gherkin is a set of grammar rules that makes plain text structured enough
-for Cucumber to understand. The scenario above is written in Gherkin.
+Gherkin is a set of grammar rules that makes plain text structured enough for
+Cucumber to understand. The scenario above is written in Gherkin.
 
 Gherkin serves multiple purposes:
 
@@ -50,30 +50,34 @@ Gherkin serves multiple purposes:
 The Cucumber grammar exists in different flavours for many [spoken languages](/docs/gherkin/reference#spoken-languages)
 so that your team can use the keywords in your own language.
 
-Gherkin documents are stored in `.feature` text files and are typically versioned in source control
-alongside the software.
+Gherkin documents are stored in `.feature` text files and are typically
+versioned in source control alongside the software.
 
 See the [Gherkin reference](/docs/gherkin) for more details.
 
 {{% note "Who should write Gherkin?" %}}
-It's usually best to let developers write Gherkin if the team is practicing BDD (test first).
+It's usually best to let developers write Gherkin if the team is practicing BDD
+(test first).
 
-If Cucumber is used solely as a test automation tool (test after) it can be done by
-testers or developers.
+If Cucumber is used solely as a test automation tool (test after) it can be done
+by testers or developers.
 
-It is usually counterproductive to let product owners and business analysts write Gherkin.
-Instead, we recommend they participate in [Example Mapping](/docs/bdd/example-mapping) sessions
-and **approve** the Gherkin documents after a developer or tester has translated it to Gherkin.
+It is usually counterproductive to let product owners and business analysts
+write Gherkin. Instead, we recommend they participate in [Example Mapping](/docs/bdd/example-mapping)
+sessions and **approve** the Gherkin documents after a developer or tester has
+translated it to Gherkin.
 {{% /note %}}
 
-# Step Definitions
+# What are Step Definitions?
 
-In addition to [feature files](/docs/gherkin/reference#feature), Cucumber needs a set of [step definitions](/docs/cucumber/step-definitions). Step definitions map (or "glue") each
-Gherkin step to programming code to carry out the  action that should be performed by the step.
+[Step definitions](/docs/cucumber/step-definitions) connect Gherkin steps to
+programming code. A step definition carries out the action that should be
+performed by the step. So step definitions hard-wire the specification to the
+implementation.
 
-Step definitions hard-wire the specification to the implementation.
-
-<!-- TODO: Illustration (Feature) - (Step Defs) -> (System) -->
+```
+ | Steps in Gherkin | --matched with--> | Step Definitions | --manipulates--> | System |
+```
 
 Step definitions can be written in many programming languages. Here is an example
 using JavaScript:
@@ -85,5 +89,6 @@ When("{maker} starts a game", function(maker) {
 ```
 
 {{% note "Who should write step definitions?" %}}
-The same people who write Gherkin should be writing step definitions. This is another reason the Gherkin is best written by developers and/or testers.
+The same people who write Gherkin should be writing step definitions. This is
+another reason the Gherkin is best written by developers and/or testers.
 {{% /note %}}

--- a/content/docs/guides/overview.md
+++ b/content/docs/guides/overview.md
@@ -3,12 +3,11 @@ title: Introduction
 subtitle: New to Cucumber? Start here!
 weight: 1000
 ---
-# What is Cucumber?
-
 Cucumber is a tool that supports [Behaviour-Driven Development(BDD)](/docs/bdd).
 If you're new to Behaviour-Driven Development read our [BDD introduction](/docs/bdd)
 first.
 
+# What is Cucumber?
 Ok, now that you know that BDD is about discovery, collaboration and examples
 (and not testing), let's take a look at Cucumber.
 

--- a/content/docs/guides/overview.md
+++ b/content/docs/guides/overview.md
@@ -72,7 +72,11 @@ performed by the step. So step definitions hard-wire the specification to the
 implementation.
 
 ```
- | Steps in Gherkin | --matched with--> | Step Definitions | --manipulates--> | System |
+┌────────────┐                 ┌──────────────┐                 ┌───────────┐
+│   Steps    │                 │     Step     │                 │           │
+│ in Gherkin ├──matched with──▶│ Definitions  ├───manipulates──▶│  System   │
+│            │                 │              │                 │           │
+└────────────┘                 └──────────────┘                 └───────────┘
 ```
 
 Step definitions can be written in many programming languages. Here is an example

--- a/content/docs/guides/overview.md
+++ b/content/docs/guides/overview.md
@@ -51,19 +51,6 @@ versioned in source control alongside the software.
 
 See the [Gherkin reference](/docs/gherkin) for more details.
 
-{{% note "Who should write Gherkin?" %}}
-It's usually best to let developers write Gherkin if the team is practicing BDD
-(test first).
-
-If Cucumber is used solely as a test automation tool (test after) it can be done
-by testers or developers.
-
-It is usually counterproductive to let product owners and business analysts
-write Gherkin. Instead, we recommend they participate in [Example Mapping](/docs/bdd/example-mapping)
-sessions and **approve** the Gherkin documents after a developer or tester has
-translated it to Gherkin.
-{{% /note %}}
-
 # What are Step Definitions?
 
 [Step definitions](/docs/cucumber/step-definitions) connect Gherkin steps to
@@ -87,8 +74,3 @@ When("{maker} starts a game", function(maker) {
   maker.startGameWithWord({ word: "whale" })
 })
 ```
-
-{{% note "Who should write step definitions?" %}}
-The same people who write Gherkin should be writing step definitions. This is
-another reason the Gherkin is best written by developers and/or testers.
-{{% /note %}}


### PR DESCRIPTION
- Both the Gherkin and the Cucumber section follow the Q&A pattern.
  For consistency the Step Definition section should follow this
  pattern.

- Step Definition section referenced feature files. A concept not
  introduced prior. Change this to reference Gherkin steps in instead
  (which have been introduced before)

- Diagram was missing. Added some ASCII art.

- Removed BDD snark from introduction.

- Inlined the prompt to read about BDD first. This is the first thing users will read.
No need to preempt it with a notice before they've even started.

- There seems to be a bit of a contradiction between these two pages:

  https://cucumber.io/docs/guides/overview/#what-is-gherkin
   - developers write Gherkin 
   - testers or developers if used as a test automation tool.
   - not by product owners and business analysts write Gherk

  https://cucumber.io/docs/bdd/who-does-what/
   - initially written by a domain expert.
   - reviewed & edited by devs
   - reviewed by domain expert

  Removing the notes from the intro resolves the contradiction in favour of
the more nuanced bdd introduction.