### PR TITLE
Fix grammar

### DIFF
--- a/content/docs/cucumber/cucumber-expressions.md
+++ b/content/docs/cucumber/cucumber-expressions.md
@@ -145,7 +145,7 @@ Argument      | Description
 # Optional text
 
 It's grammatically incorrect to say *1 cucumbers*, so we should make the plural **s**
-optional. That can be done by surrounding the optional text with parenthesis:
+optional. That can be done by surrounding the optional text with parentheses:
 
     I have {int} cucumber(s) in my belly
 
@@ -157,8 +157,8 @@ It would also match this text:
 
     I have 42 cucumbers in my belly
 
-In Regular Expressions, parenthesis means capture group, but in Cucumber Expressions
-it means *optional text*.
+In Regular Expressions, parentheses indicate a capture group, but in Cucumber Expressions
+they mean *optional text*.
 
 # Alternative text
 


### PR DESCRIPTION
"Parenthesis" is singular; the plural is "parentheses" (just like crisis/crises); see https://www.merriam-webster.com/dictionary/parenthesis.