### PR TITLE
updates exception path to cucumber.api.PendingException()

### DIFF
--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -625,19 +625,19 @@ You can implement missing steps with the snippets below:
 @Given("today is Sunday")
 public void today_is_Sunday() {
     // Write code here that turns the phrase above into concrete actions
-    throw new io.cucumber.java.PendingException();
+    throw new cucumber.api.PendingException();
 }
 
 @When("I ask whether it's Friday yet")
 public void i_ask_whether_it_s_Friday_yet() {
     // Write code here that turns the phrase above into concrete actions
-    throw new io.cucumber.java.PendingException();
+    throw new cucumber.api.PendingException();
 }
 
 @Then("I should be told {string}")
 public void i_should_be_told(String string) {
     // Write code here that turns the phrase above into concrete actions
-    throw new io.cucumber.java.PendingException();
+    throw new cucumber.api.PendingException();
 }
 ```
 {{% /block %}}


### PR DESCRIPTION
The example text did not correspond to what the terminal returns, leading to confusion for new people following the tutorial not noticing that they need to copy the snippets from their terminal in order to have access to the given exception, and not from the tutorial.