### PR TITLE
Update to 10 minute tutorial

### DIFF
--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -160,23 +160,6 @@ test {
 }
 ```
 
-Then add a file `src/test/java/hellocucumber/RunCucumberTest.java` inside the project
-to enable JUnit 5 integration:
-
-```java
-package hellocucumber;
-
-import io.cucumber.junit.Cucumber;
-import io.cucumber.junit.CucumberOptions;
-import org.junit.runner.RunWith;
-
-@RunWith(Cucumber.class)
-@CucumberOptions(plugin = "pretty", features = "src/test/resources/hellocucumber")
-public class RunCucumberTest
-{
-}
-```
-
 If you have not already, open the project in IntelliJ IDEA:
 
 * **File -> Open... -> (Select build.gradle)**

--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -125,7 +125,7 @@ Open the project in IntelliJ IDEA:
 
 **With Gradle**
 
-The easiest way to create this sample Cucumber project using Gradle is to convert the above generated Maven archetype into a Gradle project.
+One way to create this sample Cucumber project using Gradle is to convert the above generated Maven archetype into a Gradle project.
 
 Run the following command from the `hellocucumber` directory:
 

--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -125,40 +125,29 @@ Open the project in IntelliJ IDEA:
 
 **With Gradle**
 
-You can use the following `build.gradle` file as an example template. Use your IDE
-to start a new Gradle-based project.
+The easiest way to create this sample Cucumber project using Gradle is to convert the above generated Maven archetype into a Gradle project.
 
+Run the following command from the `hellocucumber` directory:
+
+```shell
+gradle init
+```
+
+Add the following Task to your `build.gradle` file:
 ```groovy
-apply plugin: 'java'
-sourceCompatibility = 11
-targetCompatibility = 11
-
-group = "hellocucumber"
-version = "1.0"
-
-// Versioning of dependencies
-wrapper.gradleVersion = '5.5.1'
-def cucumberVersion = '{{% version "cucumberjvm" %}}'
-def junitVersion = '5.5.0'
-
-repositories {
-    jcenter()
-    mavenCentral()
-}
-
-dependencies {
-    testImplementation "io.cucumber:cucumber-java:${cucumberVersion}"
-    testImplementation "io.cucumber:cucumber-junit:${cucumberVersion}"
-
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
-}
-
-test {
-    useJUnitPlatform()
+task cucumber() {
+    dependsOn assemble, compileTestJava
+    doLast {
+        javaexec {
+            main = "io.cucumber.core.cli.Main"
+            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
+            args = ['--plugin', 'pretty', '--glue', 'gradle.cucumber', 'src/test/resources']
+        }
+    }
 }
 ```
+Note that you also need to add the necessary dependencies/configurations to `build.gradle` depending on which version of Gradle you are using.
+See the [Build Tools](https://cucumber.io/docs/tools/java/#gradle) section.
 
 If you have not already, open the project in IntelliJ IDEA:
 
@@ -436,8 +425,14 @@ You now have a small project with Cucumber installed.
 To make sure everything works together correctly, let's run Cucumber.
 
 {{% block "java,kotlin" %}}
+**Maven:**
 ```shell
 mvn test
+```
+
+**Gradle:**
+```shell
+gradle cucumber
 ```
 {{% /block %}}
 
@@ -558,10 +553,15 @@ The last three lines starting with `Given`, `When` and `Then` are the
 Now that we have a scenario, we can ask Cucumber to execute it.
 
 {{% block "java,kotlin" %}}
+**Maven:**
 ```shell
 mvn test
 ```
 
+**Gradle:**
+```shell
+gradle cucumber
+```
 {{% /block %}}
 
 {{% block "javascript" %}}

--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -147,7 +147,7 @@ task cucumber() {
 }
 ```
 Note that you also need to add the necessary dependencies/configurations to `build.gradle` depending on which version of Gradle you are using.
-See the [Build Tools](https://cucumber.io/docs/tools/java/#gradle) section.
+See the [Build Tools](/docs/tools/java/#gradle) section.
 
 If you have not already, open the project in IntelliJ IDEA:
 

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -4,7 +4,7 @@
 #
 
 cucumberjvm: "4.7.4"
-cucumberarchetype: "4.2.6.1"
+cucumberarchetype: "4.8.0.0"
 cucumberjs: "5.0.3"
 cucumberruby: "3.1.0"
 rspec: "3.7.0"


### PR DESCRIPTION
Removed the snippet for adding the `RunCucumberTest.java` file completely, as version 4.2.6 automatically creates this file for you when you generate the archetype.

Fixes: #367