### PR TITLE
#314 - adding information on Maven profiles (Fixes #314)

### DIFF
--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -325,12 +325,8 @@ output.
 {{% /block %}}
 
 ## Default Profile
-{{% block "java" %}}
+{{% block "java,kotlin" %}}
 Cucumber profiles are not available on Cucumber-JVM. See above.
-{{% /block %}}
-
-{{% block "kotlin" %}}
-Cucumber profiles are not available in Kotlin.  See above.
 {{% /block %}}
 
 {{% block "javascript" %}}

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -231,7 +231,48 @@ This is just a convention though; Cucumber will pick them up from any file{{% te
 # Profiles
 
 {{% block "java" %}}
-Profiles are not available in Java.
+Profiles are not available in Java.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
+
+For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:
+
+``` xml
+    <profiles>
+        <profile>
+          <id>dev</id>
+            <properties>
+                <cucumber.options>--tags @dev</cucumber.options>
+                <base.url>http://dev.base.url.to.application</base.url>
+            </properties>
+        </profile>
+        <profile>
+          <id>qa</id>
+            <properties>
+                <cucumber.options>--tags @qa</cucumber.options>
+                <base.url>http://qa.base.url.to.application</base.url>
+            </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            ...
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <configuration>
+                    <systemPropertyVariables>
+                       <cucumber.options>${cucumber.options}</cucumber.options>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+```
+
+To mimick similar behavior using Gradle, see the Gradle docs on [Migrating Maven profiles and properties](https://docs.gradle.org/current/userguide/migrating_from_maven.html#migmvn:profiles_and_properties).
+
+
 {{% /block %}}
 
 {{% block "kotlin" %}}
@@ -293,7 +334,9 @@ output.
 
 ## Default Profile
 {{% block "java" %}}
-Profiles are not available in Java.
+Profiles are not available in Java.  See above.
+
+
 {{% /block %}}
 
 {{% block "kotlin" %}}

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -271,47 +271,6 @@ For instance, we can configure separate profiles for scenarios which are to be r
 To mimick similar behavior using Gradle, see the Gradle docs on [Migrating Maven profiles and properties](https://docs.gradle.org/current/userguide/migrating_from_maven.html#migmvn:profiles_and_properties).
 {{% /block %}}
 
-{{% block "kotlin" %}}
-Profiles are not available in Kotlin.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
-
-For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:
-
-``` xml
-    <profiles>
-        <profile>
-          <id>dev</id>
-            <properties>
-                <cucumber.options>--tags "@dev and not @ignore"</cucumber.options>
-            </properties>
-        </profile>
-        <profile>
-          <id>qa</id>
-            <properties>
-                <cucumber.options>--tags "@qa"</cucumber.options>
-            </properties>
-        </profile>
-    </profiles>
-
-    <build>
-        <plugins>
-            ...
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
-                <configuration>
-                    <systemPropertyVariables>
-                       <cucumber.options>${cucumber.options}</cucumber.options>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-```
-
-To mimick similar behavior using Gradle, see the Gradle docs on [Migrating Maven profiles and properties](https://docs.gradle.org/current/userguide/migrating_from_maven.html#migmvn:profiles_and_properties).
-{{% /block %}}
-
 {{% block "javascript" %}}
 For more information on how to use profiles with Cucumber-js, please see the [profiles.feature](https://github.com/cucumber/cucumber-js/blob/master/features/profiles.feature).
 {{% /block %}}

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -230,8 +230,8 @@ This is just a convention though; Cucumber will pick them up from any file{{% te
 
 # Profiles
 
-{{% block "java" %}}
-Profiles are not available in Java.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
+{{% block "java, kotlin" %}}
+Cucumber profiles are not available on Cucumber-JVM.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
 
 For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:
 
@@ -240,15 +240,13 @@ For instance, we can configure separate profiles for scenarios which are to be r
         <profile>
           <id>dev</id>
             <properties>
-                <cucumber.options>--tags @dev</cucumber.options>
-                <base.url>http://dev.base.url.to.application</base.url>
+                <cucumber.options>--tags "@dev and not @ignore"</cucumber.options>
             </properties>
         </profile>
         <profile>
           <id>qa</id>
             <properties>
-                <cucumber.options>--tags @qa</cucumber.options>
-                <base.url>http://qa.base.url.to.application</base.url>
+                <cucumber.options>--tags "@qa"</cucumber.options>
             </properties>
         </profile>
     </profiles>
@@ -271,12 +269,47 @@ For instance, we can configure separate profiles for scenarios which are to be r
 ```
 
 To mimick similar behavior using Gradle, see the Gradle docs on [Migrating Maven profiles and properties](https://docs.gradle.org/current/userguide/migrating_from_maven.html#migmvn:profiles_and_properties).
-
-
 {{% /block %}}
 
 {{% block "kotlin" %}}
-Profiles are not available in Kotlin.
+Profiles are not available in Kotlin.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
+
+For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:
+
+``` xml
+    <profiles>
+        <profile>
+          <id>dev</id>
+            <properties>
+                <cucumber.options>--tags "@dev and not @ignore"</cucumber.options>
+            </properties>
+        </profile>
+        <profile>
+          <id>qa</id>
+            <properties>
+                <cucumber.options>--tags "@qa"</cucumber.options>
+            </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            ...
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <configuration>
+                    <systemPropertyVariables>
+                       <cucumber.options>${cucumber.options}</cucumber.options>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+```
+
+To mimick similar behavior using Gradle, see the Gradle docs on [Migrating Maven profiles and properties](https://docs.gradle.org/current/userguide/migrating_from_maven.html#migmvn:profiles_and_properties).
 {{% /block %}}
 
 {{% block "javascript" %}}
@@ -334,13 +367,13 @@ output.
 
 ## Default Profile
 {{% block "java" %}}
-Profiles are not available in Java.  See above.
+Cucumber profiles are not available on Cucumber-JVM. See above.
 
 
 {{% /block %}}
 
 {{% block "kotlin" %}}
-Profiles are not available in Kotlin.
+Cucumber profiles are not available in Kotlin.  See above.
 {{% /block %}}
 
 {{% block "javascript" %}}

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -368,8 +368,6 @@ output.
 ## Default Profile
 {{% block "java" %}}
 Cucumber profiles are not available on Cucumber-JVM. See above.
-
-
 {{% /block %}}
 
 {{% block "kotlin" %}}

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -230,7 +230,7 @@ This is just a convention though; Cucumber will pick them up from any file{{% te
 
 # Profiles
 
-{{% block "java, kotlin" %}}
+{{% block "java,kotlin" %}}
 Cucumber profiles are not available on Cucumber-JVM.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
 
 For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:


### PR DESCRIPTION
https://github.com/cucumber/docs.cucumber.io/issues/314
Added to the profiles section for the JVM a bit about how to set something up using Maven profiles.  I couldn't get a working example done in Gradle, but I linked to some documentation I found on mimicking similar behavior.