### PR TITLE
Remove inconsistent --i18n section

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -440,24 +440,6 @@ configuration, so you don't need to place the `# language` header in every file.
 ## Gherkin Dialects
 In order to allow Gherkin to be written in a number of languages, the keywords have been translated into multiple languages. To improve readability and flow, some languages may have more than one translation for any given keyword.
 
-### List translation options
-You can get information about the translations from the command line.
-
-To see a listing of available languages:
-```shell
-cucumber --i18n help
-```
-
-To list the keywords of a particular language, use the language code:
-```shell
-cucumber --i18n <language_code>
-```
-
-For example, to see the keywords in French:
-```shell
-cucumber --i18n fr
-```
-
 ### Overview
 You can find all translation of Gherkin [on GitHub](https://github.com/cucumber/cucumber/blob/master/gherkin/gherkin-languages.json).
 This is also the place to add or update translations.


### PR DESCRIPTION
As a follow up for cucumber/common#412, remove the "List translation options" section, as the commands are inconsistent across implementations, and might be removed anyway (see https://github.com/cucumber/cucumber/issues/783).
