### PR TITLE
update docs for Rule, regarding Background

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -102,7 +102,7 @@ You can write anything you like, as long as no line starts with a keyword.
 The (optional) `Rule` keyword has been part of Gherkin since v6. 
 
 {{% note "Cucumber Support for Rule"%}}
-Not all Cucumber implementations have added support for the `Rule` keyword.
+Not all Cucumber implementations have finished implementing support for the `Rule` keyword - see [this issue](https://github.com/cucumber/cucumber/issues/869) for the latest status.
 {{% /note %}}
 
 The purpose of the `Rule` keyword is to represent one *business rule* that should be implemented.

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -267,7 +267,7 @@ Example: Multiple Givens
 
 ## Background
 
-Occasionally you'll find yourself repeating the same `Given` steps in all of the scenarios in a `Feature` or `Rule`.
+Occasionally you'll find yourself repeating the same `Given` steps in all of the scenarios in a `Feature`.
 
 Since it is repeated in every scenario, this is an indication that those steps
 are not *essential* to describe the scenarios; they are *incidental details*. You can literally move such `Given` steps to the background, by grouping them under a `Background` section.
@@ -276,7 +276,7 @@ A `Background` allows you to add some context to the scenarios that follow it. I
 
 A `Background` is placed before the first `Scenario`/`Example`, at the same level of indentation.
 
-For example, at the `Feature` level:
+For example:
 
 ```gherkin
 Feature: Multiple site support
@@ -305,7 +305,7 @@ Feature: Multiple site support
     Then I should see "Your article was published."
 ```
 
-And, at the `Rule` level:
+`Background` is also supported at the `Rule` level, for example:
 
 ```gherkin
 Feature: Overdue tasks
@@ -328,9 +328,11 @@ Feature: Overdue tasks
   ...
 ```
 
-You can only have one set of `Background` steps per `Feature` or `Rule`. If you need different `Background` steps for different scenarios, consider breaking up your set of scenarios into more `Rule`s or more `Feature`s.
+{{% warn "Use with caution"%}}
+Whilst usage of `Background` within `Rule` is currently supported, it's not recommended, and may be removed in future versions of Gherkin.
+{{% /warn %}}
 
-You would typically place a `Background` at either `Feature` or `Rule` level, but you can do _both_ if you need to; the steps will be run in hierarchical order, so the `Feature` ones first, followed by the `Rule` ones.
+You can only have one set of `Background` steps per `Feature` or `Rule`. If you need different `Background` steps for different scenarios, consider breaking up your set of scenarios into more `Rule`s or more `Feature`s.
 
 For a less explicit alternative to `Background`, check out [conditional hooks](/docs/cucumber/api/#conditional-hooks).
 

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -272,12 +272,11 @@ Occasionally you'll find yourself repeating the same `Given` steps in all of the
 Since it is repeated in every scenario, this is an indication that those steps
 are not *essential* to describe the scenarios; they are *incidental details*. You can literally move such `Given` steps to the background, by grouping them under a `Background` section.
 
-A `Background` allows you to add some context to the scenarios that follow it. It can contain one or
-more `Given` steps.
+A `Background` allows you to add some context to the scenarios that follow it. It can contain one or more `Given` steps, which are run before *each* scenario, but after any [Before hooks](/docs/cucumber/api/#hooks).
 
-A `Background` is run before *each* scenario, but after any [Before hooks](/docs/cucumber/api/#hooks). In your feature file, put the `Background` before the first `Scenario`/`Example`.
+A `Background` is placed before the first `Scenario`/`Example`, at the same level of indentation.
 
-For example:
+For example, at the `Feature` level:
 
 ```gherkin
 Feature: Multiple site support
@@ -306,10 +305,32 @@ Feature: Multiple site support
     Then I should see "Your article was published."
 ```
 
-You can only have one set of `Background` steps at the `Feature` level. If you need different `Background` steps for different scenarios, you have a couple of options:
+And, at the `Rule` level:
 
-- Split the scenarios up into different feature files
-- If it makes sense, consider grouping the scenarios together by business rule using [the `Rule` keyword](#rule), and adding a different `Background` to each `Rule`
+```gherkin
+Feature: Overdue tasks
+  Let users know when tasks are overdue, even when using other
+  features of the app
+
+  Rule: Users are notified about overdue tasks on first use of the day
+    Background:
+      Given I have overdue tasks
+
+    Example: First use of the day
+      Given I last used the app yesterday
+      When I use the app
+      Then I am notified about overdue tasks
+
+    Example: Already used today
+      Given I last used the app earlier today
+      When I use the app
+      Then I am not notified about overdue tasks
+  ...
+```
+
+You can only have one set of `Background` steps per `Feature` or `Rule`. If you need different `Background` steps for different scenarios, consider breaking up your set of scenarios into more `Rule`s or more `Feature`s.
+
+You would typically place a `Background` at either `Feature` or `Rule` level, but you can do _both_ if you need to; the steps will be run in hierarchical order, so the `Feature` ones first, followed by the `Rule` ones.
 
 For a less explicit alternative to `Background`, check out [conditional hooks](/docs/cucumber/api/#conditional-hooks).
 

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -85,7 +85,7 @@ The name and the optional description have no special meaning to Cucumber. Their
 a place for you to document important aspects of the feature, such as a brief explanation
 and a list of business rules (general acceptance criteria).
 
-The free format description for `Feature` ends when you start a line with the keyword `Rule`, `Example` or `Scenario Outline` (or their alias keywords).
+The free format description for `Feature` ends when you start a line with the keyword `Background`, `Rule`, `Example` or `Scenario Outline` (or their alias keywords).
 
 You can place [tags](/docs/cucumber/api/#tags) above `Feature` to group related features,
 independent of your file and directory structure.
@@ -99,7 +99,12 @@ You can write anything you like, as long as no line starts with a keyword.
 
 ## Rule
 
-The (optional) `Rule` keyword has been added in Gherkin v6. (Note that Gherkin 6 has not yet been incorporated into all implementation of Cucumber!)
+The (optional) `Rule` keyword has been part of Gherkin since v6. 
+
+{{% note "Cucumber Support for Rule"%}}
+Not all Cucumber implementations have added support for the `Rule` keyword.
+{{% /note %}}
+
 The purpose of the `Rule` keyword is to represent one *business rule* that should be implemented.
 It provides additional information for a feature.
 A `Rule` is used to group together several scenarios
@@ -262,17 +267,15 @@ Example: Multiple Givens
 
 ## Background
 
-Occasionally you'll find yourself repeating the same `Given` steps in all of the scenarios in a feature.
+Occasionally you'll find yourself repeating the same `Given` steps in all of the scenarios in a `Feature` or `Rule`.
 
 Since it is repeated in every scenario, this is an indication that those steps
 are not *essential* to describe the scenarios; they are *incidental details*. You can literally move such `Given` steps to the background, by grouping them under a `Background` section.
 
-A `Background` allows you to add some context to the scenarios in the feature. It can contain one or
+A `Background` allows you to add some context to the scenarios that follow it. It can contain one or
 more `Given` steps.
 
-A `Background` is run before *each* scenario, but after any [Before hooks](/docs/cucumber/api/#hooks). In your feature file, put the `Background` before the first `Scenario`.
-
-You can only have one set of `Background` steps per feature. If you need different `Background` steps for different scenarios, you'll need to split them into different feature files.
+A `Background` is run before *each* scenario, but after any [Before hooks](/docs/cucumber/api/#hooks). In your feature file, put the `Background` before the first `Scenario`/`Example`.
 
 For example:
 
@@ -302,6 +305,11 @@ Feature: Multiple site support
     When I try to post to "Expensive Therapy"
     Then I should see "Your article was published."
 ```
+
+You can only have one set of `Background` steps at the `Feature` level. If you need different `Background` steps for different scenarios, you have a couple of options:
+
+- Split the scenarios up into different feature files
+- If it makes sense, consider grouping the scenarios together by business rule using [the `Rule` keyword](#rule), and adding a different `Background` to each `Rule`
 
 For a less explicit alternative to `Background`, check out [conditional hooks](/docs/cucumber/api/#conditional-hooks).
 

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -329,7 +329,7 @@ Feature: Overdue tasks
 ```
 
 {{% warn "Use with caution"%}}
-Whilst usage of `Background` within `Rule` is currently supported, it's not recommended, and may be removed in future versions of Gherkin.
+Whilst usage of `Background` within `Rule` is currently supported, it's not recommended, and [may be removed](https://github.com/cucumber/cucumber/issues/590) in future versions of Gherkin.
 {{% /warn %}}
 
 You can only have one set of `Background` steps per `Feature` or `Rule`. If you need different `Background` steps for different scenarios, consider breaking up your set of scenarios into more `Rule`s or more `Feature`s.


### PR DESCRIPTION
When implementing Rule support for JS in https://github.com/cucumber/cucumber-js/pull/1273, noticed that, per [the messages spec](https://github.com/cucumber/cucumber/blob/master/cucumber-messages/messages.proto#L199), a `Rule` can have a `Background`. The docs passively contradict this; looking at the history it has gone back and forth a bit, but latest update seems to be that it _is_ supported.

So this updates the section for `Background` to say it can be used under `Rule`. I've tried to provide some advice about when you might do that, which probably needs tweaking.

Also:

- Makes the warning about incomplete support in Cucumber implementations a more prominent message
- ~~Fixes a minor spacing issue with that message component~~ now in #442