### PR TITLE
TypeRegistryConfigurer is Deprecated in 5.0.0-RC2 (2019-11-22)

### DIFF
--- a/content/docs/cucumber/cucumber-expressions.md
+++ b/content/docs/cucumber/cucumber-expressions.md
@@ -80,14 +80,18 @@ output parameters to your own types. Consider this Cucumber Expression:
 If we want the `{color}` output parameter to be converted to a `Color` object,
 we can define a custom parameter type in Cucumber's [configuration](/docs/cucumber/configuration).
 
+{{% block "java8" %}}
+```java
+ ParameterType("color", "red|blue|yellow", Color::new);
+```
+{{% /block %}}
 {{% block "java" %}}
 ```java
-typeRegistry.defineParameterType(new ParameterType<>(
-    "color",           // name
-    "red|blue|yellow", // regexp
-    Color.class,       // type
-    Color::new         // transformer function
-))
+@ParameterType(".*?")
+public Color currency(String value) {
+    return new Color(value);
+}
+ @ParameterType("color", "red|blue|yellow", Color::new)
 ```
 {{% /block %}}
 

--- a/content/docs/cucumber/cucumber-expressions.md
+++ b/content/docs/cucumber/cucumber-expressions.md
@@ -91,7 +91,6 @@ we can define a custom parameter type in Cucumber's [configuration](/docs/cucumb
 public Color currency(String value) {
     return new Color(value);
 }
- @ParameterType("color", "red|blue|yellow", Color::new)
 ```
 {{% /block %}}
 


### PR DESCRIPTION
TypeRegistryConfigurer is Deprecated in 5.0.0-RC2 (2019-11-22) and new way to use custom parameter type is to use
Deprecated
[Core] Deprecate TypeRegistryConfigurer (#1809 Anton Deriabin)
Use @ParameterType and friends instead when using annotation glue.
Use ParameterType and friends instead when using lambda glue.