### PR TITLE
Update Cucumber JVM to 5.1.0

### DIFF
--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -97,7 +97,7 @@ and run the following command:
 mvn archetype:generate                      \
    "-DarchetypeGroupId=io.cucumber"           \
    "-DarchetypeArtifactId=cucumber-archetype" \
-   "-DarchetypeVersion={{% version "cucumberarchetype" %}}"               \
+   "-DarchetypeVersion={{% version "cucumberjvm" %}}"               \
    "-DgroupId=hellocucumber"                  \
    "-DartifactId=hellocucumber"               \
    "-Dpackage=hellocucumber"                  \

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -3,8 +3,7 @@
 # They can be referred to with the custom Hugo shortcode, e.g. {{% version "cucumberjvm" %}}
 #
 
-cucumberjvm: "5.0.0"
-cucumberarchetype: "5.0.0.0"
+cucumberjvm: "5.1.0"
 cucumberjs: "5.0.3"
 cucumberruby: "3.1.0"
 rspec: "3.7.0"

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -3,7 +3,7 @@
 # They can be referred to with the custom Hugo shortcode, e.g. {{% version "cucumberjvm" %}}
 #
 
-cucumberjvm: "5.1.0"
+cucumberjvm: "5.1.1"
 cucumberjs: "5.0.3"
 cucumberruby: "3.1.0"
 rspec: "3.7.0"


### PR DESCRIPTION
Note that the maven archetype has been merged into the Cucumber-JVM
project and follows the same versioning