### PR TITLE
Document asterisk for steps in Gherkin reference

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -260,6 +260,32 @@ Example: Multiple Givens
   But I shouldn't see something else
 ```
 
+### Star Notation
+
+Gherkin also supports a "star" notation for steps, where the `*` character can be used in place of any of the normal step keywords. This can helpful when you have some steps that are effectively a _list of things_, so you can express it more like bullet points where otherwise the natural language of `And` etc might not read so elegantly.
+
+For example:
+
+```gherkin
+Example: List of setup items
+  Given some base context
+  And one thing
+  And another thing
+  And yet another thing
+  When I do something
+```
+
+Could be expressed as:
+
+```gherkin
+Example: List of setup items
+  Given some base context
+  * one thing
+  * another thing
+  * yet another thing
+  When I do something
+```
+
 ## Background
 
 Occasionally you'll find yourself repeating the same `Given` steps in all of the scenarios in a feature.

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -260,9 +260,9 @@ Example: Multiple Givens
   But I shouldn't see something else
 ```
 
-### Universal Keyword
+### *
 
-Gherkin also supports a universal keyword for steps, where the `*` character can be used in place of any of the normal step keywords. This can helpful when you have some steps that are effectively a _list of things_, so you can express it more like bullet points where otherwise the natural language of `And` etc might not read so elegantly.
+Gherkin also supports using an asterisk (`*`) in place of any of the normal step keywords. This can be helpful when you have some steps that are effectively a _list of things_, so you can express it more like bullet points where otherwise the natural language of `And` etc might not read so elegantly.
 
 For example:
 

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -267,23 +267,25 @@ Gherkin also supports a "star" notation for steps, where the `*` character can b
 For example:
 
 ```gherkin
-Example: List of setup items
-  Given some base context
-  And one thing
-  And another thing
-  And yet another thing
-  When I do something
+Scenario: All done
+  Given I am out shopping
+  And I have eggs
+  And I have milk
+  And I have butter
+  When I check my list
+  Then I don't need anything
 ```
 
 Could be expressed as:
 
 ```gherkin
-Example: List of setup items
-  Given some base context
-  * one thing
-  * another thing
-  * yet another thing
-  When I do something
+Scenario: All done
+  Given I am out shopping
+  * I have eggs
+  * I have milk
+  * I have butter
+  When I check my list
+  Then I don't need anything
 ```
 
 ## Background

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -260,9 +260,9 @@ Example: Multiple Givens
   But I shouldn't see something else
 ```
 
-### Star Notation
+### Universal Keyword
 
-Gherkin also supports a "star" notation for steps, where the `*` character can be used in place of any of the normal step keywords. This can helpful when you have some steps that are effectively a _list of things_, so you can express it more like bullet points where otherwise the natural language of `And` etc might not read so elegantly.
+Gherkin also supports a universal keyword for steps, where the `*` character can be used in place of any of the normal step keywords. This can helpful when you have some steps that are effectively a _list of things_, so you can express it more like bullet points where otherwise the natural language of `And` etc might not read so elegantly.
 
 For example:
 

--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -43,7 +43,7 @@ The primary keywords are:
 - `Feature`
 - `Rule` (as of Gherkin 6)
 - `Example` (or `Scenario`)
-- `Given`, `When`, `Then`, `And`, `But`  (steps)
+- `Given`, `When`, `Then`, `And`, `But` for steps (or `*`)
 - `Background`
 - `Scenario Outline` (or `Scenario Template`)
 - `Examples`


### PR DESCRIPTION
This has been part of Gherkin for a long time but not really documented. I think I've described it accurately - the example could probably be better though.

cc @mpkorstanje 