### PR TITLE
Improve dependsOn option value in Gradle task

### DIFF
--- a/content/docs/tools/java.md
+++ b/content/docs/tools/java.md
@@ -96,7 +96,7 @@ Steps:
 
     ```groovy
     task cucumber() {
-        dependsOn assemble, compileTestJava
+        dependsOn testClasses
         doLast {
             javaexec {
                 main = "io.cucumber.core.cli.Main"


### PR DESCRIPTION
Using "testClasses" as value for dependsOn option in Gradle task is more accurate since it will also include test resources (if any)