### PR TITLE
Update 10-minute-tutorial.md

### DIFF
--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -133,6 +133,16 @@ Run the following command from the `hellocucumber` directory:
 gradle init
 ```
 
+Add next configurations cucumber runtime-settings to your `build.gradle` file:
+```groovy
+
+configurations {
+  cucumberRuntime {
+    extendsFrom testRuntime
+  }
+}
+```
+
 Add the following Task to your `build.gradle` file:
 ```groovy
 task cucumber() {


### PR DESCRIPTION
For solve next error during gradle build:
[Could not get unknown property 'cucumberRuntime' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.]
I needed added next  configuration 
```
configurations {
  cucumberRuntime {
    extendsFrom testRuntime
  }
}
```
  to the build.gradle