### PR TITLE
Create Scala documentation pages

### DIFF
--- a/content/docs/community/contributing-to-documentation.md
+++ b/content/docs/community/contributing-to-documentation.md
@@ -105,6 +105,7 @@ A language select will be displayed if the page specifies the following in the f
  - javascript
  - ruby
  - kotlin
+ - scala
  - dotnet
  ```
 
@@ -114,6 +115,7 @@ The following languages are currently supported:
 * JavaScript
 * Ruby
 * Kotlin (optional)
+* Scala (optional)
 * .Net (optional; some pages only)
 
 * Whenever possible, we prefer to have information for Java, JavaScript and Ruby.
@@ -154,6 +156,13 @@ Wrap `{{%/* block %}}` shortcodes around paragraphs and fenced code blocks:
     ```
     {{% /block */%}}
 
+    {{%/* block "scala" %}}
+    Put this in your `Hello.scala`:
+    ```scala
+    println("hello")
+    ```
+    {{% /block */%}}
+
 Please note that you cannot use headers *inside* language blocks! If you are writing a page with content for a specific language,
 perhaps it should be a separate page. Alternatively, you can use a header per language.
 
@@ -165,13 +174,13 @@ a particular programming language:
     The preferred build tool is
     {{%/* text "ruby" %}}Rake{{% /text %}}
     {{% text "javascript" %}}Yarn{{% /text %}}
-    {{% text "java,kotlin" %}}Maven{{% /text */%}}.
+    {{% text "java,kotlin,scala" %}}Maven{{% /text */%}}.
 
 ## Paragraphs or text that is valid for multiple programming languages    
 Note that you can also use shortcodes for paragraphs or text that is valid for multiple languages, without repeating it for each individual language.
 To do so, list the relevant languages separated by a comma (`,`):
     
-    {{%/* text "java,kotlin" %}}Maven{{% /text */%}}
+    {{%/* text "java,kotlin,scala" %}}Maven{{% /text */%}}
 
 ## Additional shortcodes
 Additional shortcodes are defined in `layouts/shortcodes`.

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -23,8 +23,7 @@ The number of parameters in the {{% stepdef-body %}} has to match the number of 
 
 ## Data Tables
 
-{{% text "java" %}}
-The simplest way to pass a `List<String>` to a step definition is to use a data table:
+The simplest way to pass a {{% text "java,kotlin" %}}`List<String>`{{% /text %}}{{% text "scala" %}}`java.util.List[String]`{{% /text %}} to a step definition is to use a data table:
 
 ```gherkin
 Given the following animals:
@@ -33,45 +32,36 @@ Given the following animals:
   | sheep |
 ```
 
-Declare the argument as a `List<String>`, but don't define any capture groups in the expression:
+Declare the argument as a {{% text "java,kotlin" %}}`List<String>`{{% /text %}}{{% text "scala" %}}`java.util.List[String]`{{% /text %}}, but don't define any capture groups in the expression:
 
+{{% text "java" %}}
 ```java
 @Given("the following animals:")
 public void the_following_animals(List<String> animals) {
 }
 ```
+{{% /text %}}
 
+{{% text "kotlin" %}}
 ```kotlin
 @Given("the following animals:")
 fun the_following_animals(animals: List<String>) {
 }
 ```
-
-In this case, the `DataTable` is automatically flattened to a `List<String>`
-by Cucumber (using `DataTable.asList(String.class)`) before invoking the step definition.
 {{% /text %}}
 
 {{% text "scala" %}}
-The simplest way to pass a `java.util.List[String]` to a step definition is to use a data table:
-
-```gherkin
-Given the following animals:
-  | cow   |
-  | horse |
-  | sheep |
-```
-
-Declare the argument as a `java.util.List[String]`, but don't define any capture groups in the expression:
-
 ```scala
 Given("the following animals:") { animals: java.util.List[String] =>
 }
 ```
+{{% /text %}}
 
-In this case, the `DataTable` is automatically flattened to a `java.util.List[String]`
-by Cucumber (using `DataTable.asList(classOf[String])`) before invoking the step definition.
+In this case, the `DataTable` is automatically flattened to a {{% text "java,kotlin" %}}`List<String>`{{% /text %}}{{% text "scala" %}}`java.util.List[String]`{{% /text %}}
+by Cucumber (using `DataTable.asList(String.class)`) before invoking the step definition.
 
-For now, Cucumber Scala does not support using Scala collection types.
+{{% text "scala" %}}
+**Note:** For now, Cucumber Scala does not support using Scala collection types.
 See [Github](https://github.com/cucumber/cucumber-jvm-scala/issues/50).
 {{% /text %}}
 
@@ -90,13 +80,13 @@ Given I have 93 cucumbers in my belly
 
 In this step, you're "calling" the above step definition with one argument: the value `93`.
 
-Steps are declared in your {{% text "ruby" %}}`features/\*.feature`{{% /text %}}{{% text "java" %}}`*.feature`{{% /text %}}{{% text "scala" %}}`*.feature`{{% /text %}}{{% text "javascript" %}}`*.feature`{{% /text %}} files.
+Steps are declared in your {{% text "ruby" %}}`features/\*.feature`{{% /text %}}{{% text "java,kotlin,scala" %}}`*.feature`{{% /text %}}{{% text "javascript" %}}`*.feature`{{% /text %}} files.
 
 ## Matching steps
 
 1. Cucumber matches a step against a step definition's `Regexp`
 2. Cucumber gathers any capture groups or variables
-3. Cucumber passes them to the step definition's {{% text "ruby" %}}`Proc` (or “function”){{% /text %}}{{% text "javascript" %}}function{{% /text %}}{{% text "java" %}}method{{% /text %}}{{% text "scala" %}}method{{% /text %}} and executes it
+3. Cucumber passes them to the step definition's {{% text "ruby" %}}`Proc` (or “function”){{% /text %}}{{% text "javascript" %}}function{{% /text %}}{{% text "java,scala" %}}method{{% /text %}} and executes it
 
 Recall that step definitions start with a [preposition](https://www.merriam-webster.com/dictionary/given) or an [adverb](https://www.merriam-webster.com/dictionary/when) (**`Given`**, **`When`**, **`Then`**, **`And`**, **`But`**).
 
@@ -128,7 +118,7 @@ When a step definition's method or function invokes the `pending` method, the st
 
 When a step definition's method or function is executed and raises an error, the step is marked as failed (red). What you return from a step definition has no significance whatsoever.
 
-Returning {{% text "ruby" %}}`nil`{{% /text %}}{{% text "java" %}}`null`{{% /text %}}{{% text "scala" %}}`null`{{% /text %}}{{% text "javascript" %}}`null`{{% /text %}} or `false` will **not** cause a step definition to fail.
+Returning {{% text "ruby" %}}`nil`{{% /text %}}{{% text "java,kotlin,scala" %}}`null`{{% /text %}}{{% text "javascript" %}}`null`{{% /text %}} or `false` will **not** cause a step definition to fail.
 
 #### Skipped
 
@@ -138,8 +128,7 @@ Steps that follow `undefined`, `pending`, or `failed` steps are never executed, 
 
 Step definitions have to be unique for Cucumber to know what to execute.
 If you use ambiguous step definitions,{{% text "ruby" %}}Cucumber will raise a `Cucumber::Ambiguous` error,{{% /text %}}
-{{% text "java" %}} Cucumber will raise an `AmbiguousStepDefinitionsException`,{{% /text %}}
-{{% text "scala" %}} Cucumber will raise an `AmbiguousStepDefinitionsException`,{{% /text %}}
+{{% text "java,kotlin,scala" %}} Cucumber will raise an `AmbiguousStepDefinitionsException`,{{% /text %}}
 {{% text "javascript" %}}the step / scenario will get an "Ambiguous" result,{{% /text %}}
 telling you to fix the ambiguity.
 
@@ -409,11 +398,11 @@ Around('@fast') do |scenario, block|
 end
 ```
 
-{{% block "java,scala" %}}Cucumber-JVM does not support `Around` hooks.{{% /block %}}
+{{% block "java,kotlin,scala" %}}Cucumber-JVM does not support `Around` hooks.{{% /block %}}
 {{% block "javascript" %}}Cucumber.js does not support `Around` hooks.{{% /block %}}
 
 ## Step hooks
-{{% text "java,scala" %}}
+{{% text "java,kotlin,scala" %}}
 Step hooks invoked before and after a step. The hooks have 'invoke around' semantics. Meaning that if a `BeforeStep`
 hook is executed the `AfterStep` hooks will also be executed regardless of the result of the step. If a step did not
 pass, the following step and its hooks will be skipped.
@@ -510,8 +499,7 @@ AfterStep { scenario: Scenario =>
 
 Hooks can be conditionally selected for execution based on the tags of the scenario.
 To run a particular hook only for certain scenarios, you can associate a
-{{% text "java" %}}`Before` or `After`{{% /text %}}
-{{% text "scala" %}}`Before` or `After`{{% /text %}}
+{{% text "java,kotlin,scala" %}}`Before` or `After`{{% /text %}}
 {{% text "javascript" %}}`Before` or `After`{{% /text %}}
 {{% text "ruby" %}}`Before`, `After`, `Around` or `AfterStep`{{% /text %}}
 hook with a [tag expression](#tag-expressions).
@@ -587,7 +575,7 @@ at_exit do
 end
 ```
 
-{{% block "java,scala" %}}Cucumber-JVM does not support global hooks.{{% /block %}}
+{{% block "java,kotlin,scala" %}}Cucumber-JVM does not support global hooks.{{% /block %}}
 {{% block "javascript" %}}Cucumber.js does not support global hooks.{{% /block %}}
 
 ## Running a hook only once
@@ -606,7 +594,7 @@ end
 ```
 {{% /text %}}
 
-{{% block "java,scala" %}}Cucumber-JVM does not support running a hook only once.{{% /block %}}
+{{% block "java,kotlin,scala" %}}Cucumber-JVM does not support running a hook only once.{{% /block %}}
 {{% block "javascript" %}}Cucumber.js does not support running a hook only once.{{% /block %}}
 
 ## AfterConfiguration
@@ -629,7 +617,7 @@ This hook will run _only once_: after support has been loaded, and before any fe
 You can use this hook to extend Cucumber. For example you could affect how features are loaded, or register custom formatters programmatically.
 {{% /text %}}
 
-{{% text "java,scala" %}}Cucumber-JVM does not support `AfterConfiguration` hooks.{{% /text %}}
+{{% text "java,kotlin,scala" %}}Cucumber-JVM does not support `AfterConfiguration` hooks.{{% /text %}}
 {{% text "javascript" %}}Cucumber js does not support `AfterConfiguration` hooks.{{% /text %}}
 
 # Tags
@@ -903,7 +891,7 @@ By default, Cucumber will treat anything ending in
 {{% text "kotlin" %}}`.kt`{{% /text %}}
 {{% text "javascript" %}}`.js`{{% /text %}}
 {{% text "ruby" %}}`.rb`{{% /text %}} under the root
-{{% text "java,kotlin,javascript,scala" %}}resource{{% /text %}}
+{{% text "java,kotlin,scala,javascript" %}}resource{{% /text %}}
 {{% text "ruby" %}}library{{% /text %}} directory as a step definition file.
 
 Thus, a step contained in
@@ -913,7 +901,7 @@ Thus, a step contained in
 {{% text "javascript" %}}`features/models/entities/step-definitions/anything.js`{{% /text %}}
 {{% text "ruby" %}}`features/models/entities/step_definitions/anything.rb`{{% /text %}}
 can be used in a feature file contained in
-{{% text "java,kotlin,javascript,scala" %}}`features/views/entity-new`{{% /text %}}
+{{% text "java,kotlin,scala,javascript" %}}`features/views/entity-new`{{% /text %}}
 {{% text "ruby" %}}`features/views/entity_new`{{% /text %}}
 , provided that:
 
@@ -1447,7 +1435,7 @@ cucumber --help
 ```
 {{% /block %}}
 
-{{% block "java,scala" %}}
+{{% block "java,kotlin,scala" %}}
 Pass the `--help` option to print out all the available configuration options:
 
 ```
@@ -1462,7 +1450,7 @@ Use the `cucumber-js --help` command to see which arguments can be passed to the
 
 You can also use [tags](#tags) to specify what to run.
 
-{{% block "java,scala" %}}
+{{% block "java,kotlin,scala" %}}
 Configuration options can also be overridden and passed to *any* of the runners via the `cucumber.options` Java system property.
 
 For example, if you are using Maven and want to run a subset of scenarios tagged

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -6,6 +6,7 @@ polyglot:
  - javascript
  - ruby
  - kotlin
+ - scala
 
 weight: 2
 ---
@@ -50,6 +51,30 @@ In this case, the `DataTable` is automatically flattened to a `List<String>`
 by Cucumber (using `DataTable.asList(String.class)`) before invoking the step definition.
 {{% /text %}}
 
+{{% text "scala" %}}
+The simplest way to pass a `java.util.List[String]` to a step definition is to use a data table:
+
+```gherkin
+Given the following animals:
+  | cow   |
+  | horse |
+  | sheep |
+```
+
+Declare the argument as a `java.util.List[String]`, but don't define any capture groups in the expression:
+
+```scala
+Given("the following animals:") { animals: java.util.List[String] =>
+}
+```
+
+In this case, the `DataTable` is automatically flattened to a `java.util.List[String]`
+by Cucumber (using `DataTable.asList(classOf[String])`) before invoking the step definition.
+
+For now, Cucumber Scala does not support using Scala collection types.
+See [Github](https://github.com/cucumber/cucumber-jvm-scala/issues/50).
+{{% /text %}}
+
 {{% text "javascript" %}} For an example of data tables in JavaScript, go
 [here](https://github.com/cucumber/cucumber-js/blob/master/src/models/data_table.ts) {{% /text %}}
 
@@ -65,13 +90,13 @@ Given I have 93 cucumbers in my belly
 
 In this step, you're "calling" the above step definition with one argument: the value `93`.
 
-Steps are declared in your {{% text "ruby" %}}`features/\*.feature`{{% /text %}}{{% text "java" %}}`*.feature`{{% /text %}}{{% text "javascript" %}}`*.feature`{{% /text %}} files.
+Steps are declared in your {{% text "ruby" %}}`features/\*.feature`{{% /text %}}{{% text "java" %}}`*.feature`{{% /text %}}{{% text "scala" %}}`*.feature`{{% /text %}}{{% text "javascript" %}}`*.feature`{{% /text %}} files.
 
 ## Matching steps
 
 1. Cucumber matches a step against a step definition's `Regexp`
 2. Cucumber gathers any capture groups or variables
-3. Cucumber passes them to the step definition's {{% text "ruby" %}}`Proc` (or “function”){{% /text %}}{{% text "javascript" %}}function{{% /text %}}{{% text "java" %}}method{{% /text %}} and executes it
+3. Cucumber passes them to the step definition's {{% text "ruby" %}}`Proc` (or “function”){{% /text %}}{{% text "javascript" %}}function{{% /text %}}{{% text "java" %}}method{{% /text %}}{{% text "scala" %}}method{{% /text %}} and executes it
 
 Recall that step definitions start with a [preposition](https://www.merriam-webster.com/dictionary/given) or an [adverb](https://www.merriam-webster.com/dictionary/when) (**`Given`**, **`When`**, **`Then`**, **`And`**, **`But`**).
 
@@ -103,7 +128,7 @@ When a step definition's method or function invokes the `pending` method, the st
 
 When a step definition's method or function is executed and raises an error, the step is marked as failed (red). What you return from a step definition has no significance whatsoever.
 
-Returning {{% text "ruby" %}}`nil`{{% /text %}}{{% text "java" %}}`null`{{% /text %}}{{% text "javascript" %}}`null`{{% /text %}} or `false` will **not** cause a step definition to fail.
+Returning {{% text "ruby" %}}`nil`{{% /text %}}{{% text "java" %}}`null`{{% /text %}}{{% text "scala" %}}`null`{{% /text %}}{{% text "javascript" %}}`null`{{% /text %}} or `false` will **not** cause a step definition to fail.
 
 #### Skipped
 
@@ -114,6 +139,7 @@ Steps that follow `undefined`, `pending`, or `failed` steps are never executed, 
 Step definitions have to be unique for Cucumber to know what to execute.
 If you use ambiguous step definitions,{{% text "ruby" %}}Cucumber will raise a `Cucumber::Ambiguous` error,{{% /text %}}
 {{% text "java" %}} Cucumber will raise an `AmbiguousStepDefinitionsException`,{{% /text %}}
+{{% text "scala" %}} Cucumber will raise an `AmbiguousStepDefinitionsException`,{{% /text %}}
 {{% text "javascript" %}}the step / scenario will get an "Ambiguous" result,{{% /text %}}
 telling you to fix the ambiguity.
 
@@ -127,6 +153,10 @@ If you want more fine-grained control, you can use [conditional hooks](#conditio
 
 {{% text "java" %}}
 You can declare hooks in any class.
+{{% /text %}}
+
+{{% text "scala" %}}
+You can declare hooks in any class, trait or object.
 {{% /text %}}
 
 {{% text "ruby" %}}
@@ -169,6 +199,14 @@ Lambda style:
 
 ```kotlin
 Before { scenario: Scenario ->
+    // doSomething
+}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+Before { scenario: Scenario =>
     // doSomething
 }
 ```
@@ -226,7 +264,7 @@ Only use a `Before` hook for low-level logic such as starting a browser or delet
 data from a database.
 {{% /tip %}}
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 You can specify an explicit order for hooks if you need to.
 {{% /block %}}
 
@@ -252,6 +290,14 @@ Before(10, () -> {
 {{% block "kotlin" %}}
 ```kotlin
 Before(10) { scenario: Scenario ->
+    // Do something before each scenario
+}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+Before(10) { scenario: Scenario =>
     // Do something before each scenario
 }
 ```
@@ -300,6 +346,15 @@ After { scenario: Scenario ->
 
 {{% /block %}}
 
+{{% block "scala" %}}
+```scala
+After { scenario: Scenario =>
+    // doSomething
+}
+```
+
+{{% /block %}}
+
 {{% block "javascript" %}}
 
 ```javascript
@@ -322,7 +377,7 @@ The `scenario` parameter is optional. If you use it, you can inspect the status
 of the scenario.
 
 For example, you can take a screenshot with
-{{% text "java,javascript,kotlin" %}}[WebDriver](https://www.seleniumhq.org/projects/webdriver/){{% /text %}}{{% text "ruby" %}}[Capybara](https://github.com/teamcapybara/capybara){{% /text %}}
+{{% text "java,javascript,kotlin,scala" %}}[WebDriver](https://www.seleniumhq.org/projects/webdriver/){{% /text %}}{{% text "ruby" %}}[Capybara](https://github.com/teamcapybara/capybara){{% /text %}}
 for failed scenarios and embed them in Cucumber's report.
 
 See the [browser automation page](/docs/guides/browser-automation/#screenshot-on-failure) for an example on how to do so.
@@ -354,11 +409,11 @@ Around('@fast') do |scenario, block|
 end
 ```
 
-{{% block "java" %}}Cucumber-JVM does not support `Around` hooks.{{% /block %}}
+{{% block "java,scala" %}}Cucumber-JVM does not support `Around` hooks.{{% /block %}}
 {{% block "javascript" %}}Cucumber.js does not support `Around` hooks.{{% /block %}}
 
 ## Step hooks
-{{% text "java" %}}
+{{% text "java,scala" %}}
 Step hooks invoked before and after a step. The hooks have 'invoke around' semantics. Meaning that if a `BeforeStep`
 hook is executed the `AfterStep` hooks will also be executed regardless of the result of the step. If a step did not
 pass, the following step and its hooks will be skipped.
@@ -389,6 +444,14 @@ Lambda style:
 
 ```kotlin
 BeforeStep { scenario: Scenario ->
+    // doSomething
+}
+```
+{{% /text %}}
+
+{{% text "scala" %}}
+```scala
+BeforeStep { scenario: Scenario =>
     // doSomething
 }
 ```
@@ -432,6 +495,15 @@ AfterStep { scenario: Scenario ->
 
 {{% /block %}}
 
+{{% block "scala" %}}
+```scala
+AfterStep { scenario: Scenario =>
+    // doSomething
+}
+```
+
+{{% /block %}}
+
 {{% block "javascript" %}}Cucumber.js does not support `AfterStep` hooks.{{% /block %}}
 
 ## Conditional hooks
@@ -439,6 +511,7 @@ AfterStep { scenario: Scenario ->
 Hooks can be conditionally selected for execution based on the tags of the scenario.
 To run a particular hook only for certain scenarios, you can associate a
 {{% text "java" %}}`Before` or `After`{{% /text %}}
+{{% text "scala" %}}`Before` or `After`{{% /text %}}
 {{% text "javascript" %}}`Before` or `After`{{% /text %}}
 {{% text "ruby" %}}`Before`, `After`, `Around` or `AfterStep`{{% /text %}}
 hook with a [tag expression](#tag-expressions).
@@ -466,6 +539,14 @@ Lambda style:
 ```kotlin
 After (arrayOf(@browser and not @headless")) { scenario: Scenario ->
     driver.quit()
+}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+After("@browser and not @headless") { scenario: Scenario =>
+    
 }
 ```
 {{% /block %}}
@@ -506,7 +587,7 @@ at_exit do
 end
 ```
 
-{{% block "java" %}}Cucumber-JVM does not support global hooks.{{% /block %}}
+{{% block "java,scala" %}}Cucumber-JVM does not support global hooks.{{% /block %}}
 {{% block "javascript" %}}Cucumber.js does not support global hooks.{{% /block %}}
 
 ## Running a hook only once
@@ -525,7 +606,7 @@ end
 ```
 {{% /text %}}
 
-{{% block "java" %}}Cucumber-JVM does not support running a hook only once.{{% /block %}}
+{{% block "java,scala" %}}Cucumber-JVM does not support running a hook only once.{{% /block %}}
 {{% block "javascript" %}}Cucumber.js does not support running a hook only once.{{% /block %}}
 
 ## AfterConfiguration
@@ -548,7 +629,7 @@ This hook will run _only once_: after support has been loaded, and before any fe
 You can use this hook to extend Cucumber. For example you could affect how features are loaded, or register custom formatters programmatically.
 {{% /text %}}
 
-{{% text "java" %}}Cucumber-JVM does not support `AfterConfiguration` hooks.{{% /text %}}
+{{% text "java,scala" %}}Cucumber-JVM does not support `AfterConfiguration` hooks.{{% /text %}}
 {{% text "javascript" %}}Cucumber js does not support `AfterConfiguration` hooks.{{% /text %}}
 
 # Tags
@@ -602,7 +683,7 @@ Tags that are placed above a `Scenario Outline` will be inherited by `Examples`.
 
 You can tell Cucumber to only run scenarios with a particular tag:
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 Using a JVM system property:
 
 ```shell
@@ -637,6 +718,13 @@ class RunCucumberTest {}
 ```
 {{% /block %}}
 
+{{% block "scala" %}}
+```scala
+@CucumberOptions(tags = "@smoke and @fast")
+class RunCucumberTest {}
+```
+{{% /block %}}
+
 {{% block "javascript" %}}
 ```shell
 # You can omit the quotes if the expression is a single tag
@@ -666,6 +754,13 @@ public class RunCucumberTest {}
 
 {{% block "kotlin" %}}
  ```kotlin
+@CucumberOptions(tags = "not @smoke")
+class RunCucumberTest {}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+ ```scala
 @CucumberOptions(tags = "not @smoke")
 class RunCucumberTest {}
 ```
@@ -789,10 +884,10 @@ unspecified scenarios to manageable levels. Those following [Kanban](https://en.
 # Running Cucumber
 
 Cucumber is a
-{{% text "java,kotlin" %}}JUnit extension.{{% /text %}}
+{{% text "java,kotlin,scala" %}}JUnit extension.{{% /text %}}
 {{% text "javascript,ruby" %}}command line tool.{{% /text %}}
 It is launched by running
-{{% text "java,kotlin" %}}JUnit from your build tool or your IDE.{{% /text %}}
+{{% text "java,kotlin,scala" %}}JUnit from your build tool or your IDE.{{% /text %}}
 {{% text "javascript" %}}`cucumber-js` from the command line, or a build script.{{% /text %}}
 {{% text "ruby" %}}`cucumber` from the command line, or a build script.{{% /text %}}
 
@@ -804,19 +899,21 @@ The most common option is to run Cucumber from the command line.
 
 By default, Cucumber will treat anything ending in
 {{% text "java" %}}`.java`{{% /text %}}
+{{% text "scala" %}}`.scala`{{% /text %}}
 {{% text "kotlin" %}}`.kt`{{% /text %}}
 {{% text "javascript" %}}`.js`{{% /text %}}
 {{% text "ruby" %}}`.rb`{{% /text %}} under the root
-{{% text "java,kotlin,javascript" %}}resource{{% /text %}}
+{{% text "java,kotlin,javascript,scala" %}}resource{{% /text %}}
 {{% text "ruby" %}}library{{% /text %}} directory as a step definition file.
 
 Thus, a step contained in
 {{% text "java" %}}`features/models/entities/step-definitions/anything.java`{{% /text %}}
 {{% text "kotlin" %}}`features/models/entities/step-definitions/anything.kt`{{% /text %}}
+{{% text "scala" %}}`features/models/entities/step-definitions/anything.scala`{{% /text %}}
 {{% text "javascript" %}}`features/models/entities/step-definitions/anything.js`{{% /text %}}
 {{% text "ruby" %}}`features/models/entities/step_definitions/anything.rb`{{% /text %}}
 can be used in a feature file contained in
-{{% text "java,kotlin,javascript" %}}`features/views/entity-new`{{% /text %}}
+{{% text "java,kotlin,javascript,scala" %}}`features/views/entity-new`{{% /text %}}
 {{% text "ruby" %}}`features/views/entity_new`{{% /text %}}
 , provided that:
 
@@ -842,7 +939,7 @@ cucumber
 
 {{% /block %}}
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 The **Command-Line Interface Runner (CLI Runner)** is an executable Java class that can be run from the command-line.
 
 ```
@@ -895,7 +992,7 @@ You can also run features using a [build tool](/docs/tools/general#build-tools) 
 
 ## JUnit
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 To use JUnit to execute cucumber scenarios add the `cucumber-junit` dependency to your pom.
 
 ```xml
@@ -941,6 +1038,19 @@ class RunCucumberTest {
 }
 ```
 
+```scala
+package com.example
+
+import io.cucumber.junit.Cucumber
+import io.cucumber.junit.CucumberOptions
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions()
+class RunCucumberTest {
+}
+```
+
 This will execute all scenarios in same package as the runner, by default glue code is also assumed to be in the same
 package.
 
@@ -981,6 +1091,21 @@ class RunCucumberTest {
 ```
 {{% /block %}}
 
+{{% block "scala" %}}
+```scala
+package com.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(plugin = Seq("pretty", "html:target/cucumber"))
+class RunCucumberTest {
+}
+```
+{{% /block %}}
+
 For example if you want to tell Cucumber to print code snippets for missing
 step definitions use the `summary` plugin, you can specify it like this:
 
@@ -1009,6 +1134,21 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = {"pretty", "summary"}, strict = true, snippets = CAMELCASE)
+class RunCucumberTest {
+}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+package com.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(plugin = Seq("pretty", "summary"), strict = true, snippets = CAMELCASE)
 class RunCucumberTest {
 }
 ```
@@ -1045,6 +1185,19 @@ import org.junit.runner.RunWith;
 class RunCucumberTest {
 }
 ```
+
+```scala
+package com.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(dryRun=true)
+class RunCucumberTest {
+}
+```
 The default option for `dryRun` is `false`.
 
 **Formatting console output:**
@@ -1077,6 +1230,19 @@ class RunCucumberTest {
 }
 ```
 
+```scala
+package com.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(monochrome=true)
+class RunCucumberTest {
+}
+```
+
 The default option for `monochrome` is `false`.
 
 **Skip undefined tests:**
@@ -1097,6 +1263,19 @@ public class RunCucumberTest {
 ```
 
 ```kotlin
+package com.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(strict=false)
+class RunCucumberTest {
+}
+```
+
+```scala
 package com.example;
 
 import io.cucumber.junit.Cucumber;
@@ -1144,6 +1323,21 @@ public class RunCucumberTest {
 ```
 {{% /block %}}
 
+{{% block "scala" %}}
+```scala
+package com.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(tags = Seq("@foo", "not @bar"))
+public class RunCucumberTest {
+}
+```
+{{% /block %}}
+
 **Specify an object factory:**
 
 For example if you are using Cucumber with a DI framework and want to use a custom object factory, you can specify it like this:
@@ -1172,6 +1366,21 @@ import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
+@CucumberOptions(objectFactory = FooFactory.class)
+public class RunCucumberTest {
+}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+package com.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(classOf[Cucumber])
 @CucumberOptions(objectFactory = FooFactory.class)
 public class RunCucumberTest {
 }
@@ -1238,7 +1447,7 @@ cucumber --help
 ```
 {{% /block %}}
 
-{{% block "java" %}}
+{{% block "java,scala" %}}
 Pass the `--help` option to print out all the available configuration options:
 
 ```
@@ -1253,7 +1462,7 @@ Use the `cucumber-js --help` command to see which arguments can be passed to the
 
 You can also use [tags](#tags) to specify what to run.
 
-{{% block "java" %}}
+{{% block "java,scala" %}}
 Configuration options can also be overridden and passed to *any* of the runners via the `cucumber.options` Java system property.
 
 For example, if you are using Maven and want to run a subset of scenarios tagged

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -8,20 +8,21 @@ polyglot:
  - javascript
  - ruby
  - kotlin
+ - scala
 
 ---
 
 
 # Type Registry
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 Parameter types let you convert parameters from cucumber-expressions to objects.
 Data table and doc string types let you convert data tables and doc
 strings to objects. Like step definitions, type definitions are part of the glue.
 When placed on the glue path Cucumber will detect them automatically. 
 {{% /block %}}
 
-{{% block "java" %}}
+{{% block "java,scala" %}}
 For example, the following class registers a custom "Author" data table type:
 {{% /block %}}
 
@@ -80,7 +81,30 @@ class StepDefinitions {
 ```
 {{% /block %}}
 
-{{% block "java,kotlin" %}}
+{{% block "scala" %}}
+
+```scala
+package com.example
+
+import io.cucumber.scala.{ScalaDsl, EN}
+
+class StepDefinitions extends ScalaDsl with EN {
+
+    DataTableType { entry: Map[String, String] =>
+        Author(
+            entry("firstName"),
+            entry("lastName"),
+            entry("famousBook"))
+    }
+
+    Given("There are my favorite authors") { authors: List[Author] =>
+        // step implementation
+    }
+}
+```
+{{% /block %}}
+
+{{% block "java,kotlin,scala" %}}
 
 The parameter type example:
 
@@ -132,9 +156,28 @@ class StepDefinitions {
 }
 ```
 
+{{% block "scala" %}}
+
+```scala
+package com.example
+
+import io.cucumber.scala.{ScalaDsl, EN}
+
+class StepDefinitions extends ScalaDsl with EN {
+
+    ParameterType("book", ".*") { bookName: String =>
+        Book(bookName)
+    }
+
+    Given("{book} is my favorite book") { book: Book =>
+        // step implementation
+    }
+}
+```
+
 {{% /block %}}
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 
 The docstring type example:
 
@@ -194,6 +237,34 @@ class StepsDefinitions {
 
     @Given("Books are defined by json")
     fun books_are_defined_by_json(books: JsonNode) {
+        // step implementation
+    }
+}
+```
+
+{{% /block %}}
+
+{{% block "scala" %}}
+
+```scala
+package com.example
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.cucumber.scala.{ScalaDsl, EN}
+
+object StepsDefinitions {
+    private val objectMapper = ObjectMapper()
+}
+
+class StepsDefinitions extends ScalaDsl with EN {
+
+    DocStringType("json") { docString: String =>
+        objectMapper.readValue(docString, classOf[JsonNode])
+    }
+
+    Given("Books are defined by json") { books: JsonNode =>
         // step implementation
     }
 }
@@ -280,6 +351,13 @@ ObjectMapper. The object mapper (Jackson in this example) will handle the
 conversion of anonymous parameter types and data table entries.
 {{% /block %}}
 
+{{% block "scala" %}}
+Using the `DefaultParameterTransformer`, `DefaultDataTableEntryTransformer`
+and `DefaultDataTableCellTransformer` methods, it is also possible to plug in an 
+ObjectMapper. The object mapper (Jackson in this example) will handle the 
+conversion of anonymous parameter types and data table entries.
+{{% /block %}}
+
 {{% block "java" %}}
 
 ```java
@@ -326,6 +404,34 @@ class StepDefinitions {
     @DefaultDataTableCellTransformer
     fun transformer(fromValue: Any, toValueType: Type): Any {
         return objectMapper.convertValue(fromValue, objectMapper.constructType(toValueType))
+    }
+}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+package com.example
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.cucumber.scala.ScalaDsl
+
+import java.lang.reflect.Type
+
+class StepDefinitions extends ScalaDsl {
+
+    private val objectMapper = ObjectMapper()
+
+    DefaultParameterTransformer { (fromValue: String, toValueType: Type) => 
+        objectMapper.convertValue(fromValue, objectMapper.constructType(toValueType)) 
+    }
+
+    DefaultDataTableCellTransformer { (fromValue: String, toValueType: Type) => 
+        objectMapper.convertValue(fromValue, objectMapper.constructType(toValueType)) 
+    }
+
+    DefaultDataTableEntryTransformer { (fromValue: Map[String, String], toValueType: Type) => 
+        objectMapper.convertValue(fromValue, objectMapper.constructType(toValueType))
     }
 }
 ```
@@ -413,7 +519,7 @@ end
 ```
 {{% /block %}}
 
-{{% block "java,kotlin,ruby" %}}
+{{% block "java,kotlin,scala,ruby" %}}
 If you are using a type that has not yet been defined, you will get an error similar to:
 ```shell
 The parameter type "person" is not defined.
@@ -429,14 +535,20 @@ For more information on how to use `Data Tables` with Cucumber-js, please see th
 
 {{% /block %}}
 
+{{% block "scala" %}}
+If you want to, you can use the predefined `JacksonDefaultDataTableEntryTransformer` trait which defines default transformers using Jackson Scala Module.
+
+See [Default Jackon DataTable Transformer](https://github.com/cucumber/cucumber-jvm-scala/blob/master/docs/default_jackson_datatable_transformer.md).
+{{% /block %}}
+
 ## Recommended location
 
-The recommended location to define custom parameter types, would be in{{% text "ruby" %}} `features/support/parameter_types.rb`.{{% /text %}}{{% text "javascript" %}} `features/support/parameter_types.js`.{{% /text %}}{{% text "java" %}} `src/test/java/com/example/ParameterTypes.java`.{{% /text %}}{{% text "kotlin" %}} `src/test/kotlin/com/example/ParameterTypes.kt`.{{% /text %}}
-This is just a convention though; Cucumber will pick them up from any file{{% text "ruby, javascript" %}} under features.{{% /text %}}{{% text "java,kotlin" %}} on the glue path.{{% /text %}}
+The recommended location to define custom parameter types, would be in{{% text "ruby" %}} `features/support/parameter_types.rb`.{{% /text %}}{{% text "javascript" %}} `features/support/parameter_types.js`.{{% /text %}}{{% text "java" %}} `src/test/java/com/example/ParameterTypes.java`.{{% /text %}}{{% text "kotlin" %}} `src/test/kotlin/com/example/ParameterTypes.kt`.{{% /text %}}{{% text "scala" %}} `src/test/kotlin/com/example/ParameterTypes.scala`.{{% /text %}}
+This is just a convention though; Cucumber will pick them up from any file{{% text "ruby, javascript" %}} under features.{{% /text %}}{{% text "java,kotlin,scala" %}} on the glue path.{{% /text %}}
 
 # Profiles
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 Cucumber profiles are not available on Cucumber-JVM.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
 
 For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:
@@ -531,7 +643,7 @@ output.
 {{% /block %}}
 
 ## Default Profile
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 Cucumber profiles are not available on Cucumber-JVM. See above.
 {{% /block %}}
 
@@ -566,7 +678,7 @@ progress output and HTML output.
 
 ## Preprocessing with ERB
 
-{{% block "java,kotlin,javascript" %}}
+{{% block "java,kotlin,scala,javascript" %}}
 ERB (Embedded RuBy) is a Ruby specific tool.
 {{% /block %}}
 
@@ -588,7 +700,7 @@ So, if you have several profiles with similar values, you might do this:
 {{% /block %}}
 
 # Environment Variables
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 Cucumber-JVM does not support configuration of Cucumber with an `env` file.
 {{% /block %}}
 

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -22,7 +22,7 @@ strings to objects. Like step definitions, type definitions are part of the glue
 When placed on the glue path Cucumber will detect them automatically. 
 {{% /block %}}
 
-{{% block "java,scala" %}}
+{{% block "java,kotlin,scala" %}}
 For example, the following class registers a custom "Author" data table type:
 {{% /block %}}
 

--- a/content/docs/cucumber/cucumber-expressions.md
+++ b/content/docs/cucumber/cucumber-expressions.md
@@ -6,6 +6,7 @@ polyglot:
  - javascript
  - ruby
  - kotlin
+ - scala
 
 weight: 4
 markup: mmark
@@ -59,7 +60,7 @@ Parameter Type  | Description
 `{string}`      | Matches single-quoted or double-quoted strings, for example `"banana split"` or `'banana split'` (but not `banana split`). Only the text between the quotes will be extracted. The quotes themselves are discarded. Empty pairs of quotes are valid and will be matched and passed to step code as empty strings.
 `{}` anonymous  | Matches anything (`/.*/`). 
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 On the JVM, there are additional parameter types for `biginteger`, `bigdecimal`,
 `byte`, `short`, `long` and `double`. 
 
@@ -94,6 +95,14 @@ public Color color(String color){  // type, name (from method)
 @ParameterType("red|blue|yellow")   // regexp
 fun color(color: String): Color {   // name (from method), type
     return Color(color)             // transformer function
+}                                    
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+ParameterType("color", "red|blue|yellow") { color: String => // name, regexp
+    Color(color)                                             // transformer function, type
 }                                    
 ```
 {{% /block %}}
@@ -134,8 +143,8 @@ Argument      | Description
 `regexp`      | A regexp that will match the parameter. May include capture groups.
 `type`        | The return type of the transformer {{% stepdef-body %}}.
 `transformer` | A {{% stepdef-body %}} that transforms the match from the regexp. Must have arity 1 if the regexp doesn't have any capture groups. Otherwise the arity must match the number of capture groups in `regexp`.
-{{% text "java,kotlin,javascript" %}}`useForSnippets`{{% /text %}}{{% text "ruby" %}}`use_for_snippets`{{% /text %}} | Defaults to `true`. That means this parameter type will be used to generate snippets for undefined steps. If the `regexp` frequently matches text you don't intend to be used as arguments, disable its use for snippets with `false`.
-{{% text "java,kotlin,javascript" %}}`preferForRegexpMatch`{{% /text %}}{{% text "ruby" %}}`prefer_for_regexp_match`{{% /text %}} | Defaults to `false`. Set to `true` if you have step definitions that use regular expressions, and you want this parameter type to take precedence over others during a match.
+{{% text "java,kotlin,scala,javascript" %}}`useForSnippets`{{% /text %}}{{% text "ruby" %}}`use_for_snippets`{{% /text %}} | Defaults to `true`. That means this parameter type will be used to generate snippets for undefined steps. If the `regexp` frequently matches text you don't intend to be used as arguments, disable its use for snippets with `false`.
+{{% text "java,kotlin,scala,javascript" %}}`preferForRegexpMatch`{{% /text %}}{{% text "ruby" %}}`prefer_for_regexp_match`{{% /text %}} | Defaults to `false`. Set to `true` if you have step definitions that use regular expressions, and you want this parameter type to take precedence over others during a match.
 
 # Optional text
 

--- a/content/docs/cucumber/debugging.md
+++ b/content/docs/cucumber/debugging.md
@@ -6,6 +6,7 @@ polyglot:
  - javascript
  - ruby
  - kotlin
+ - scala
 
 ---
 {{% block "ruby" %}}
@@ -130,7 +131,7 @@ end
 By setting an environment variable, you can tell Cucumber to use various debugging tools, and you can combine them by setting multiple environment variables.
 {{% /block %}}
 
-{{% block "java,kotlin" %}}
+{{% block "java,kotlin,scala" %}}
 In order to debug your scenarios on the JVM, you can step through the the steps of each scenario in debug mode. 
 
 1. Set a breakpoint on the part of the code you want to debug. This might be the line you are currently getting an Exception (see your stacktrace). 

--- a/content/docs/cucumber/step-definitions.md
+++ b/content/docs/cucumber/step-definitions.md
@@ -6,6 +6,7 @@ polyglot:
  - javascript
  - ruby
  - kotlin
+ - scala
 
 weight: 1
 ---
@@ -13,6 +14,7 @@ weight: 1
 A Step Definition is a
 {{% text "java" %}}Java method{{% /text %}}
 {{% text "kotlin" %}}Kotlin function{{% /text %}}
+{{% text "scala" %}}Scala function{{% /text %}}
 {{% text "javascript" %}}JavaScript function{{% /text %}}
 {{% text "ruby" %}}Ruby block{{% /text %}}
 with an [expression](#expressions) that links it to one or more [Gherkin steps](/docs/gherkin/reference#steps).
@@ -94,6 +96,24 @@ class StepDefinitions : En {
 
 {{% /block %}}
 
+{{% block "scala" %}}
+
+```scala
+package com.example
+import io.cucumber.scala.{ScalaDsl, EN}
+
+class StepDefinitions extends ScalaDsl with EN {
+
+    Given("I have {int} cukes in my belly") { cukes: Int =>
+        prinln(s"Cukes: $cukes")
+    }
+
+}
+```
+
+{{% /block %}}
+
+
 {{% block "ruby" %}}
 ```ruby
 Given('I have {int} cukes in my belly') do |cukes|
@@ -131,6 +151,14 @@ public void i_have_n_cukes_in_my_belly(int cukes) {
 ```kotlin
 Given("I have {int} cukes in my belly") { cukes: Int ->
         prinln("Cukes: $cukes")
+}
+```
+{{% /block %}}
+
+{{% block "scala" %}}
+```scala
+Given("I have {int} cukes in my belly") { cukes: Int =>
+    prinln(s"Cukes: $cukes")
 }
 ```
 {{% /block %}}
@@ -210,6 +238,13 @@ public void i_have_red_balls(int int1) {
 ```
 {{% /block %}}
 
+{{% block "scala" %}}
+```scala
+Given("I have {int} red balls") { balls: Int =>
+}
+```
+{{% /block %}}
+
 {{% block "ruby" %}}
 ```ruby
 Given('I have {int} red balls') do |int1|
@@ -239,6 +274,13 @@ public void i_have_red_balls(int int1, Color color) {
 {{% block "kotlin" %}}
 ```kotlin
 @Given("I have {int} {color} balls") { balls: Int, color: Color ->
+}
+```
+{{% /block %}}}
+
+{{% block "scala" %}}
+```scala
+Given("I have {int} {color} balls") { (balls: Int, color: Color) =>
 }
 ```
 {{% /block %}}

--- a/content/docs/guides/upgrading.md
+++ b/content/docs/guides/upgrading.md
@@ -6,6 +6,7 @@ polyglot:
   - javascript
   - ruby
   - kotlin
+  - scala
 weight: 1700
 ---
 We try to add new features to Cucumber periodically. This means you may want to upgrade to a newer version to take advantage of these new features, as well as any bug fixes.
@@ -27,6 +28,10 @@ You can read the history file to learn about the changes in every release:
 
 {{% block "java,kotlin" %}}
 [cucumber-jvm changelog](https://github.com/cucumber/cucumber-jvm/blob/master/CHANGELOG.md)
+{{% /block %}}
+
+{{% block "scala" %}}
+[cucumber-jvm-scala changelog](https://github.com/cucumber/cucumber-jvm-scala/blob/master/CHANGELOG.md)
 {{% /block %}}
 
 {{% block "javascript" %}}

--- a/content/docs/installation/scala.md
+++ b/content/docs/installation/scala.md
@@ -27,7 +27,7 @@ Make sure the Cucumber version is the same for all Cucumber dependencies.
 <dependency>
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-scala_2.13</artifactId>
-    <version>{{% version "cucumberjvm" %}}</version>
+    <version>{{% version "cucumberscala" %}}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -37,7 +37,7 @@ You can now run Cucumber [from the command line](/docs/cucumber/api/#from-the-co
 # Sbt
 
 ```scala
-libraryDependencies += "io.cucumber" %% "cucumber-scala" % "{{% version "cucumberjvm" %}}" % Test
+libraryDependencies += "io.cucumber" %% "cucumber-scala" % "{{% version "cucumberscala" %}}" % Test
 ```
 
 # JUnit-integration

--- a/content/docs/installation/scala.md
+++ b/content/docs/installation/scala.md
@@ -1,11 +1,51 @@
 ---
 title: Cucumber-Scala
 subtitle: Scala
-img: /img/scala.png
+svg: installation/scala.svg
 implementation: unmaintained
 weight: 1315
 ---
 
+----
+
 **This package is currently in need of new maintainers.**
 
 Please see [Cucumber-Scala](https://github.com/cucumber/cucumber-jvm-scala).
+
+----
+
+Cucumber-Scala is published in the central Maven repository.
+You can install it by adding dependencies to your project.
+
+{{% note "Dependencies"%}}
+Make sure the Cucumber version is the same for all Cucumber dependencies.
+{{% /note %}}
+
+# Maven
+
+```xml
+<dependency>
+    <groupId>io.cucumber</groupId>
+    <artifactId>cucumber-scala_2.13</artifactId>
+    <version>{{% version "cucumberjvm" %}}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+You can now run Cucumber [from the command line](/docs/cucumber/api/#from-the-command-line) or [run Cucumber with Maven](/docs/tools/java#maven).
+
+# Sbt
+
+```scala
+libraryDependencies += "io.cucumber" %% "cucumber-scala" % "{{% version "cucumberjvm" %}}" % Test
+```
+
+# JUnit-integration
+
+It is also possible to use [cucumber-junit](/docs/cucumber/api/#junit) to run your Cucumber test suite.
+
+# Assertions
+
+Cucumber does not come with an assertion library. Instead, use the assertion methods
+from a [unit testing tool](/docs/cucumber/checking-assertions/#java).
+

--- a/content/docs/installation/scala.svg
+++ b/content/docs/installation/scala.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 416 416" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
+    <defs>
+        <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="linearGradient-1">
+            <stop stop-color="#4F4F4F" offset="0%"></stop>
+            <stop stop-color="#000000" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="linearGradient-2">
+            <stop stop-color="#C40000" offset="0%"></stop>
+            <stop stop-color="#FF0000" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+	<g>
+		<path d="M0,288 L0,256 C0,250.606222 116.376889,241.571556 192.199111,224 L192.199111,224 C228.828444,232.490667 256,242.968889 256,256 L256,256 L256,288 C256,301.024 228.828444,311.509333 192.199111,320 L192.199111,320 C116.376889,302.424889 0,293.390222 0,288" fill="url(#linearGradient-1)" transform="translate(208.000000, 272.000000) scale(1, -1) translate(-128.000000, -272.000000) "></path>
+		<path d="M0,160 L0,128 C0,122.606222 116.376889,113.571556 192.199111,96 L192.199111,96 C228.828444,104.490667 256,114.968889 256,128 L256,128 L256,160 C256,173.024 228.828444,183.509333 192.199111,192 L192.199111,192 C116.376889,174.424889 0,165.390222 0,160" fill="url(#linearGradient-1)" transform="translate(208.000000, 144.000000) scale(1, -1) translate(-128.000000, -144.000000) "></path>
+		<path d="M0,224 L0,128 C0,136 256,152 256,192 L256,192 L256,288 C256,248 0,232 0,224" fill="url(#linearGradient-2)" transform="translate(208.000000, 208.000000) scale(1, -1) translate(-128.000000, -208.000000) "></path>
+		<path d="M0,96 L0,0 C0,8 256,24 256,64 L256,64 L256,160 C256,120 0,104 0,96" fill="url(#linearGradient-2)" transform="translate(208.000000, 80.000000) scale(1, -1) translate(-128.000000, -80.000000) "></path>
+		<path d="M0,352 L0,256 C0,264 256,280 256,320 L256,320 L256,416 C256,376 0,360 0,352" fill="url(#linearGradient-2)" transform="translate(208.000000, 336.000000) scale(1, -1) translate(-128.000000, -336.000000) "></path>
+	</g>
+</svg>

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -4,6 +4,7 @@
 #
 
 cucumberjvm: "5.6.0"
+cucumberscala: "5.6.0"
 cucumberjs: "5.0.3"
 cucumberruby: "3.1.0"
 rspec: "3.7.0"

--- a/layouts/shortcodes/expression-parameter.html
+++ b/layouts/shortcodes/expression-parameter.html
@@ -1,4 +1,5 @@
 <span class="is-hidden text-java">capture group</span>
 <span class="is-hidden text-kotlin">capture group</span>
+<span class="is-hidden text-scala">capture group</span>
 <span class="is-hidden text-javascript">output parameter</span>
 <span class="is-hidden text-ruby">output parameter</span>

--- a/layouts/shortcodes/stepdef-body.html
+++ b/layouts/shortcodes/stepdef-body.html
@@ -1,1 +1,1 @@
-<span class="is-hidden text-java">method</span><span class="is-hidden text-javascript">function</span><span class="is-hidden text-ruby">block</span><span class="is-hidden text-kotlin">function</span>
+<span class="is-hidden text-java">method</span><span class="is-hidden text-javascript">function</span><span class="is-hidden text-ruby">block</span><span class="is-hidden text-kotlin">function</span><span class="is-hidden text-scala">function</span>

--- a/themes/cucumber-hugo/static/js/site.js
+++ b/themes/cucumber-hugo/static/js/site.js
@@ -55,6 +55,8 @@ var showHideSelectors = [
   '.text-javascript',
   '.language-kotlin',
   '.text-kotlin',
+  '.language-scala',
+  '.text-scala',
   '.language-ruby',
   '.text-ruby',
 ]

--- a/themes/cucumber-sb/static/js/site.js
+++ b/themes/cucumber-sb/static/js/site.js
@@ -55,6 +55,8 @@ var showHideSelectors = [
   '.text-javascript',
   '.language-kotlin',
   '.text-kotlin',
+  '.language-scala',
+  '.text-scala',
   '.language-ruby',
   '.text-ruby',
 ]


### PR DESCRIPTION
Now that [Cucumber Scala](https://github.com/cucumber/cucumber-jvm-scala) is to update, this PR aims to bring documentation about it in the official Cucumber docs.

It's basically adding Scala code samples in addition to Java and Kotlin ones.