### PR TITLE
gradle config to include test resources in classpath

### DIFF
--- a/content/docs/tools/java.md
+++ b/content/docs/tools/java.md
@@ -96,7 +96,7 @@ Steps:
 
     ```groovy
     task cucumber() {
-        dependsOn assemble, compileTestJava
+        dependsOn assemble, testClasses
         doLast {
             javaexec {
                 main = "io.cucumber.core.cli.Main"


### PR DESCRIPTION
the previous config only included test classes. this new config also ensures that test resources are available in the runtime classpath during execution of cucumber tests

testClasses depends on compileTestJava and processTestResources as per the gradle documentation:
https://docs.gradle.org/current/userguide/java_plugin.html