### PR TITLE
Update 10-minute-tutorial.md

### DIFF
--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -136,7 +136,7 @@ Add following dependency configuration to your build.gradle file:
 ```groovy
 configurations {
     cucumberRuntime {
-        extendsFrom testRuntime
+        extendsFrom testImplementation
     }
 }
 ```


### PR DESCRIPTION
'testRuntime' is deprecated. Use 'testImplementation' instead.
ref: https://github.com/cucumber/docs.cucumber.io/edit/master/content/docs/guides/10-minute-tutorial.md
"The compile, testCompile, runtime and testRuntime configurations inherited from the Java plugin are still available but are deprecated. You should avoid using them, as they are only kept for backwards compatibility."