### PR TITLE
Remove cucumber.options property

### DIFF
--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -1451,7 +1451,13 @@ Use the `cucumber-js --help` command to see which arguments can be passed to the
 You can also use [tags](#tags) to specify what to run.
 
 {{% block "java,kotlin,scala" %}}
-Configuration options can also be overridden and passed to *any* of the runners via the `cucumber.options` Java system property.
+When property parsing functionality is not provided by the runner (i.e.
+`cucumber-junit-platform-engine`) Cucumber will in order of precedence parse
+properties from system properties, environment variables and the
+`cucumber.properties` file.
+
+Note that options provided by `@CucumberOptions` take precedence over the
+`cucumber.properties` file. CLI arguments take precedence over all.
 
 For example, if you are using Maven and want to run a subset of scenarios tagged
 with `@smoke`:
@@ -1460,7 +1466,23 @@ with `@smoke`:
 mvn test -Dcucumber.filter.tags="@smoke"
 ```
 
-Some of the runners provide additional mechanisms for passing options to Cucumber.
+Supported properties are:
+```
+cucumber.ansi-colors.disabled=  # true or false. default: false                     
+cucumber.execution.dry-run=     # true or false. default: false 
+cucumber.execution.limit=       # number of scenarios to execute (CLI only).  
+cucumber.execution.order=       # lexical, reverse, random or random:[seed] (CLI only). default: lexical
+cucumber.execution.strict=      # true or false. default: false.
+cucumber.execution.wip=         # true or false. default: false.
+cucumber.features=              # command separated paths to feature files. example: path/to/example.feature, path/to/other.feature  
+cucumber.filter.name=           # regex. example: .*Hello.*
+cucumber.filter.tags=           # tag expression. example: @smoke and not @slow 
+cucumber.glue=                  # comma separated package names. example: com.example.glue  
+cucumber.plugin=                # comma separated plugin strings. example: pretty, json:path/to/report.json
+cucumber.object-factory=        # object factory class name. example: com.example.MyObjectFactory
+cucumber.snippet-type=          # underscore or camelcase. default: underscore
+```
+
 {{% /block %}}
 
 {{% block "ruby" %}}

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -553,18 +553,18 @@ Cucumber profiles are not available on Cucumber-JVM.  However, it is possible to
 
 For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:
 
-``` xml
+```xml
     <profiles>
         <profile>
           <id>dev</id>
             <properties>
-                <cucumber.options>--tags "@dev and not @ignore"</cucumber.options>
+                <cucumber.filter.tags>@dev and not @ignore</cucumber.filter.tags>
             </properties>
         </profile>
         <profile>
           <id>qa</id>
             <properties>
-                <cucumber.options>--tags "@qa"</cucumber.options>
+                <cucumber.filter.tags>@qa</cucumber.filter.tags>
             </properties>
         </profile>
     </profiles>
@@ -578,7 +578,7 @@ For instance, we can configure separate profiles for scenarios which are to be r
                 <version>3.0.0-M4</version>
                 <configuration>
                     <systemPropertyVariables>
-                       <cucumber.options>${cucumber.options}</cucumber.options>
+                       <cucumber.filter.tags>${cucumber.filter.tags}</cucumber.filter.tags>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/content/docs/tools/java.md
+++ b/content/docs/tools/java.md
@@ -45,8 +45,8 @@ Steps:
 4.  Run the following Maven from the directory path where the `pom.xml` file is located:
 
     ```shell
-    mvn clean install -Dcucumber.options="--glue package_name_of_step_definitions \
-       --plugin pretty path\to\featurefiles"
+    mvn clean install -Dcucumber.glue="package_name_of_step_definitions" \
+       -Dcucumber.plugin="pretty path\to\featurefiles"
     ```
 
 ## Gradle


### PR DESCRIPTION
The `cucumber.options` property was deprecated and removed in v5.
Individual properties should be used instead.