### PR TITLE
fixes typo in syntax

### DIFF
--- a/content/docs/cucumber/step-definitions.md
+++ b/content/docs/cucumber/step-definitions.md
@@ -49,7 +49,7 @@ package com.example;
 import io.cucumber.java8.En;
 
 public class StepDefinitions implements En {
-    public StepDefinitions() {
+    public void StepDefinitions() {
         Given("I have {int} cukes in my belly", (Integer cukes) -> {
             System.out.format("Cukes: %n\n", cukes);
         });


### PR DESCRIPTION
There was an 'void' missing