### PR TITLE
Use correct slashes in example URL

### DIFF
--- a/content/docs/guides/browser-automation.md
+++ b/content/docs/guides/browser-automation.md
@@ -48,7 +48,7 @@ public class ExampleSteps {
     
     @Given("I am on the Google search page")
     public void I_visit_google() {
-        driver.get("https:\\www.google.com");
+        driver.get("https://www.google.com");
     }
 
     @When("I search for {string}")


### PR DESCRIPTION
I just started learning about Cucumber, and although I haven't used it yet it would seem exceptionally unlikely to me that the URL syntax currently in the docs is actually correct for Selenium WebDriver.