### PR TITLE
Update Cucumber Java & Scala versions

### DIFF
--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -3,8 +3,8 @@
 # They can be referred to with the custom Hugo shortcode, e.g. {{% version "cucumberjvm" %}}
 #
 
-cucumberjvm: "6.6.1"
-cucumberscala: "6.1.1"
+cucumberjvm: "6.7.0"
+cucumberscala: "6.7.0"
 cucumberjs: "6.0.5"
 cucumberruby: "5.1.1"
 rspec: "3.9.0"


### PR DESCRIPTION
As 6.7.0 was recently released, we should update the documentation accordingly.

This just updates the version number.

I didn't add any new piece of doc regarding recent new features.