### PR TITLE
Don't flag Scala implementation as unmaintained anymore

### DIFF
--- a/content/docs/installation/scala.md
+++ b/content/docs/installation/scala.md
@@ -2,17 +2,9 @@
 title: Cucumber-Scala
 subtitle: Scala
 svg: installation/scala.svg
-implementation: unmaintained
-weight: 1315
+implementation: official
+weight: 1146
 ---
-
-----
-
-**This package is currently in need of new maintainers.**
-
-Please see [Cucumber-Scala](https://github.com/cucumber/cucumber-jvm-scala).
-
-----
 
 Cucumber-Scala is published in the central Maven repository.
 You can install it by adding dependencies to your project.


### PR DESCRIPTION
Now that Cucumber Scala is maintained and released at almost the same frequency than Cucumber Java, I think it's fair to not flag it anymore as "unmaintained" in the documentation.

This PR:
- mark it as "official"
- move it up in the list, just after Cucumber Kotlin
- remove the paragraph saying we are looking for maintainers

Screenshot of new installation page:

![image](https://user-images.githubusercontent.com/18280708/94341814-cdf62400-000c-11eb-8b90-a9e8bbcfb2ef.png)

