### PR TITLE
Add missing end of block

### DIFF
--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -156,6 +156,8 @@ class StepDefinitions {
 }
 ```
 
+{{% /block %}}
+
 {{% block "scala" %}}
 
 ```scala


### PR DESCRIPTION
Hello! 👋🏻 

The [configuration sections](https://cucumber.io/docs/cucumber/configuration/) for Ruby and Javascript are empty, and the sections for Java and Scala are incomplete. I believe this is due to the fact that a `{{% block "kotlin" %}}` statement is not properly closed.

#494 can probably be closed when this gets merged in.