### PR TITLE
Fixed result

### DIFF
--- a/content/docs/guides/overview.md
+++ b/content/docs/guides/overview.md
@@ -60,7 +60,7 @@ implementation.
 ```
 ┌────────────┐                 ┌──────────────┐                 ┌───────────┐
 │   Steps    │                 │     Step     │                 │           │
-│ in Gherkin ├──matched with──▶│ Definitions  ├───manipulates──▶│  System   │
+│ in Gherkin ├──matched with──>│ Definitions  ├───manipulates──>│  System   │
 │            │                 │              │                 │           │
 └────────────┘                 └──────────────┘                 └───────────┘
 ```


### PR DESCRIPTION
This looks bad on both places:
[https://cucumber.io/docs/guides/overview/](https://cucumber.io/docs/guides/overview/)
[https://github.com/cucumber/docs.cucumber.io/blob/master/content/docs/guides/overview.md](https://github.com/cucumber/docs.cucumber.io/blob/master/content/docs/guides/overview.md)

I believe that fancy arrow ('▶') is the reason...