### PR TITLE
Update deprecated method - Scenario.embed() to Scenario.attach() "Fixes #486"

### DIFF
--- a/content/docs/guides/browser-automation.md
+++ b/content/docs/guides/browser-automation.md
@@ -295,15 +295,15 @@ for failed scenarios and embed them in Cucumber's report.
 
 ```java
 if (scenario.isFailed()) {
-    byte[] screenshot = webDriver.getScreenshotAs(OutputType.BYTES);
-    scenario.embed(screenshot, "image/png");
+    byte[] screenshot = ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.BYTES);
+    scenario.attach(screenshot, "image/png", "name");
 }
 ```
 
 ```kotlin
 if (scenario.isFailed()) {
-    val screenshot = webDriver.getScreenshotAs(OutputType.BYTES)
-    scenario.embed(screenshot, "image/png")
+    val screenshot = ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.BYTES)
+    scenario.attach(screenshot, "image/png", "name")
 }
 ```
 

--- a/content/docs/guides/browser-automation.md
+++ b/content/docs/guides/browser-automation.md
@@ -331,7 +331,7 @@ for failed scenarios and embed them in Cucumber's report.
 if scenario.failed?
   path = "html-report/#{scenario.__id__}.html"
   page.driver.browser.save_screenshot(path)
-  embed(path, "image/png")
+  attach(path, "image/png")
 end
 ```
 


### PR DESCRIPTION
[5.7.0](https://github.com/cucumber/cucumber-jvm/blob/main/CHANGELOG.md#570-2020-05-01) (2020-05-01)
Added
[Java] Scenario.log(String) & Scenario.attach(byte[], String, String) (#1893 Tim te Beek)
Deprecated
[Java] Scenario.write(String) & Scenario.embed(byte[], String, String) (#1893 Tim te Beek)