### PR TITLE
Fix gradle dependsOn

### DIFF
--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -143,7 +143,7 @@ configurations {
 Add the following Task to your `build.gradle` file:
 ```groovy
 task cucumber() {
-    dependsOn assemble, compileTestJava
+    dependsOn assemble, testClasses
     doLast {
         javaexec {
             main = "io.cucumber.core.cli.Main"


### PR DESCRIPTION
Aligns the 10 minute tutorial with https://cucumber.io/docs/tools/java/
If `compileTestJava` is used, gradle will not copy resources from
`src/test/resources` into the build directory, and resources such as
`cucumber.properties` will not be found on the classpath.

See https://docs.gradle.org/current/userguide/java_plugin.html