### PR TITLE
Update cucumber-expressions.md

### DIFF
--- a/content/docs/cucumber/cucumber-expressions.md
+++ b/content/docs/cucumber/cucumber-expressions.md
@@ -184,22 +184,22 @@ Alternative text only works when there is no whitespace between the alternative 
 If you ever need to match `()` or `{}` literally, you can escape the
 opening `(` or `{` with a backslash:
 
-    I have 42 \{what} cucumber(s) in my belly \(amazing!)
+    I have {int} \{what} cucumber(s) in my belly \(amazing!)
 
 This expression would match the following examples:
 
-    I have 42 {what} cucumber in my belly (amazing!)
+    I have 1 {what} cucumber in my belly (amazing!)
     I have 42 {what} cucumbers in my belly (amazing!)
     
 You may have to escape the `\` character itself with another `\`, depending on your programming language.
 For example, in Java, you have to use escape character `\` with another backslash.
 
-    I have 42 \\{what} cucumber(s) in my belly \\(amazing!)
+    I have {int} \\{what} cucumber(s) in my belly \\(amazing!)
     
 Then this expression would match the following example:
 
-    I have 42 {what} cucumber in my belly (amazing!)
-    I have 42 {what} cucumbers in my belly (amazing!)
+    I have 1 \{what} cucumber in my belly \(amazing!)
+    I have 42 \{what} cucumbers in my belly \(amazing!)
 
 There is currently no way to escape a `/` character - it will always be interpreted
 as alternative text.


### PR DESCRIPTION
Adding an {int} so the number in the expression is compliant with the cucumber(s).
Adding the \ in the matched expressions since the backslash is escaped.