### PR TITLE
Fix case-sensitivity of anchors for keyword items

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -40,13 +40,13 @@ Each line that isn't a blank line has to start with a Gherkin *keyword*, followe
 
 The primary keywords are:
 
-- [`Feature`](#Feature)
-- [`Rule`](#Rule) (as of Gherkin 6)
-- [`Example`](#Example) (or `Scenario`)
-- [`Given`](#Given), [`When`](#When), [`Then`](#Then), [`And`](#And-But), [`But`](#And-But) for steps (or [`*`](#Asterisk))
-- [`Background`](#Background)
-- [`Scenario Outline`](#Scenario-Outline) (or [`Scenario Template`](#Scenario-Outline))
-- [`Examples`](#Examples) (or [`Scenarios`](#Examples))
+- [`Feature`](#feature)
+- [`Rule`](#rule) (as of Gherkin 6)
+- [`Example`](#example) (or `Scenario`)
+- [`Given`](#given), [`When`](#when), [`Then`](#then), [`And`](#and-but), [`But`](#and-but) for steps (or [`*`](#Asterisk))
+- [`Background`](#background)
+- [`Scenario Outline`](#scenario-outline) (or [`Scenario Template`](#scenario-outline))
+- [`Examples`](#examples) (or [`Scenarios`](#examples))
 
 There are a few secondary keywords as well:
 


### PR DESCRIPTION
According to HTML 4 specification, the comparison between fragment identifiers and anchor names is case-sensitive.
https://www.w3.org/TR/html401/struct/links.html#h-12.2.1

When the markdown document is parsed into html, the anchor name is lower case, and therefore the fragment identifier in the url link needs to match.

Currently, this [link](https://cucumber.io/docs/gherkin/reference/#Background) will just take you to the top of the page.
But this [link](https://cucumber.io/docs/gherkin/reference/#background) takes you directly to the "Background" keyword section.