### PR TITLE
Update the gherkin i18n table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ htmlproofer: hugo
 	ruby themes/cucumber-hugo/tools/htmlproofer/htmlproofer.rb
 .PHONY: htmlproofer
 
-layouts/shortcodes/gherkin-i18n-table.html: node_modules/gherkin/lib/gherkin/gherkin-languages.json layouts/shortcodes/gherkin-i18n-table-jq.txt
+layouts/shortcodes/gherkin-i18n-table.html: node_modules/@cucumber/gherkin/dist/src/gherkin-languages.json layouts/shortcodes/gherkin-i18n-table-jq.txt
 	cat $< | jq --sort-keys --from-file layouts/shortcodes/gherkin-i18n-table-jq.txt --raw-output --compact-output > $@
 
-node_modules/gherkin/lib/gherkin/gherkin-languages.json:
+node_modules/@cucumber/gherkin/dist/src/gherkin-languages.json:
 	yarn
 
 .docker-$(DOCKER_TAG): Dockerfile

--- a/layouts/shortcodes/README.md
+++ b/layouts/shortcodes/README.md
@@ -1,0 +1,15 @@
+# Gherkin Internationalization Table
+
+The table can be updated automatically using make *from the root folder of 
+the repo*:
+
+```sh
+yarn upgrade
+make layouts/shortcodes/gherkin-i18n-table.html 
+```
+
+`yarn upgrade` will upgrade `@cucumber/gherkin` to get back the last version 
+of the file `gherkin-languages.json`.
+
+`make layouts/shortcodes/gherkin-i18n-table.html` will automatically update
+`gherkin-i18n-table.html` based on `gherkin-languages.json`.

--- a/layouts/shortcodes/gherkin-i18n-table-jq.txt
+++ b/layouts/shortcodes/gherkin-i18n-table-jq.txt
@@ -15,7 +15,7 @@
         "     <tbody>\n"
       ] + (
           [ .value
-            | {"feature","background","scenario","scenarioOutline","examples","given","when","then","and","but"}
+            | {"feature","background","scenario","scenarioOutline","examples","given","when","then","and","but","rule"}
             | to_entries[]
             | "       <tr>\n",
               "         <td><code>", ([ .key ] | add), "</code></th>\n",

--- a/layouts/shortcodes/gherkin-i18n-table.html
+++ b/layouts/shortcodes/gherkin-i18n-table.html
@@ -20,7 +20,7 @@ Afrikaans (af)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Situasie</code><br></td>
+         <td><code>Voorbeeld</code><br><code>Situasie</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -50,6 +50,10 @@ Afrikaans (af)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Maar </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -74,7 +78,7 @@ Arabic (ar)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>سيناريو</code><br></td>
+         <td><code>مثال</code><br><code>سيناريو</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -104,6 +108,10 @@ Arabic (ar)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>لكن </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -128,7 +136,7 @@ Aragonese (an)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Caso</code><br></td>
+         <td><code>Eixemplo</code><br><code>Caso</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -158,6 +166,10 @@ Aragonese (an)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Pero </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -182,7 +194,7 @@ Armenian (am)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Սցենար</code><br></td>
+         <td><code>Օրինակ</code><br><code>Սցենար</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -212,6 +224,10 @@ Armenian (am)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Բայց </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -236,7 +252,7 @@ Asturian (ast)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Casu</code><br></td>
+         <td><code>Exemplo</code><br><code>Casu</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -265,6 +281,10 @@ Asturian (ast)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Peru </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -320,6 +340,10 @@ Australian (en-au)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Yeah nah </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -344,7 +368,7 @@ Azerbaijani (az)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Ssenari</code><br></td>
+         <td><code>Nümunə</code><br><code>Ssenari</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -374,6 +398,10 @@ Azerbaijani (az)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Amma </code><br><code>Ancaq </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -398,7 +426,7 @@ Bosnian (bs)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenariju</code><br><code>Scenario</code><br></td>
+         <td><code>Primjer</code><br><code>Scenariju</code><br><code>Scenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -428,6 +456,10 @@ Bosnian (bs)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ali </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -452,7 +484,7 @@ Bulgarian (bg)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Сценарий</code><br></td>
+         <td><code>Пример</code><br><code>Сценарий</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -482,6 +514,10 @@ Bulgarian (bg)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Но </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -506,7 +542,7 @@ Catalan (ca)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Escenari</code><br></td>
+         <td><code>Exemple</code><br><code>Escenari</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -535,6 +571,10 @@ Catalan (ca)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Però </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -590,6 +630,10 @@ Chinese simplified (zh-CN)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>但是</code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -643,6 +687,10 @@ Chinese traditional (zh-TW)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>但是</code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -698,6 +746,10 @@ Creole (ht)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Men </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -722,7 +774,7 @@ Croatian (hr)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenarij</code><br></td>
+         <td><code>Primjer</code><br><code>Scenarij</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -734,7 +786,7 @@ Croatian (hr)</a>
        </tr>
        <tr>
          <td><code>given</code></th>
-         <td><code>* </code><br><code>Zadan </code><br><code>Zadani </code><br><code>Zadano </code><br></td>
+         <td><code>* </code><br><code>Zadan </code><br><code>Zadani </code><br><code>Zadano </code><br><code>Ukoliko </code><br></td>
        </tr>
        <tr>
          <td><code>when</code></th>
@@ -751,6 +803,10 @@ Croatian (hr)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ali </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -776,7 +832,7 @@ Czech (cs)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scénář</code><br></td>
+         <td><code>Příklad</code><br><code>Scénář</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -806,6 +862,10 @@ Czech (cs)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ale </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -830,7 +890,7 @@ Danish (da)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenarie</code><br></td>
+         <td><code>Eksempel</code><br><code>Scenarie</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -860,6 +920,10 @@ Danish (da)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Men </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -884,7 +948,7 @@ Dutch (nl)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenario</code><br></td>
+         <td><code>Voorbeeld</code><br><code>Scenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -914,6 +978,10 @@ Dutch (nl)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Maar </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -938,7 +1006,7 @@ Emoji (em)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>📕</code><br></td>
+         <td><code>🥒</code><br><code>📕</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -968,6 +1036,10 @@ Emoji (em)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>😔</code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -992,7 +1064,7 @@ English (en)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenario</code><br></td>
+         <td><code>Example</code><br><code>Scenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1022,6 +1094,10 @@ English (en)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>But </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1046,7 +1122,7 @@ Esperanto (eo)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenaro</code><br><code>Kazo</code><br></td>
+         <td><code>Ekzemplo</code><br><code>Scenaro</code><br><code>Kazo</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1076,6 +1152,10 @@ Esperanto (eo)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Sed </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1100,11 +1180,11 @@ Estonian (et)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Stsenaarium</code><br></td>
+         <td><code>Juhtum</code><br><code>Stsenaarium</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
-         <td><code>Raamstsenaarium</code><br></td>
+         <td><code>Raamjuhtum</code><br><code>Raamstsenaarium</code><br></td>
        </tr>
        <tr>
          <td><code>examples</code></th>
@@ -1129,6 +1209,10 @@ Estonian (et)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Kuid </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Reegel</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -1184,6 +1268,10 @@ Finnish (fi)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Mutta </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1208,7 +1296,7 @@ French (fr)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scénario</code><br></td>
+         <td><code>Exemple</code><br><code>Scénario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1220,7 +1308,7 @@ French (fr)</a>
        </tr>
        <tr>
          <td><code>given</code></th>
-         <td><code>* </code><br><code>Soit </code><br><code>Etant donné que </code><br><code>Etant donné qu&apos;</code><br><code>Etant donné </code><br><code>Etant donnée </code><br><code>Etant donnés </code><br><code>Etant données </code><br><code>Étant donné que </code><br><code>Étant donné qu&apos;</code><br><code>Étant donné </code><br><code>Étant donnée </code><br><code>Étant donnés </code><br><code>Étant données </code><br></td>
+         <td><code>* </code><br><code>Soit </code><br><code>Sachant que </code><br><code>Sachant qu&apos;</code><br><code>Sachant </code><br><code>Etant donné que </code><br><code>Etant donné qu&apos;</code><br><code>Etant donné </code><br><code>Etant donnée </code><br><code>Etant donnés </code><br><code>Etant données </code><br><code>Étant donné que </code><br><code>Étant donné qu&apos;</code><br><code>Étant donné </code><br><code>Étant donnée </code><br><code>Étant donnés </code><br><code>Étant données </code><br></td>
        </tr>
        <tr>
          <td><code>when</code></th>
@@ -1228,7 +1316,7 @@ French (fr)</a>
        </tr>
        <tr>
          <td><code>then</code></th>
-         <td><code>* </code><br><code>Alors </code><br></td>
+         <td><code>* </code><br><code>Alors </code><br><code>Donc </code><br></td>
        </tr>
        <tr>
          <td><code>and</code></th>
@@ -1237,6 +1325,10 @@ French (fr)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Mais que </code><br><code>Mais qu&apos;</code><br><code>Mais </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Règle</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -1262,7 +1354,7 @@ Galician (gl)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Escenario</code><br></td>
+         <td><code>Exemplo</code><br><code>Escenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1292,6 +1384,10 @@ Galician (gl)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Mais </code><br><code>Pero </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1316,7 +1412,7 @@ Georgian (ka)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>სცენარის</code><br></td>
+         <td><code>მაგალითად</code><br><code>სცენარის</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1346,6 +1442,10 @@ Georgian (ka)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>მაგ­რამ</code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1362,19 +1462,19 @@ German (de)</a>
      <tbody>
        <tr>
          <td><code>feature</code></th>
-         <td><code>Funktionalität</code><br></td>
+         <td><code>Funktionalität</code><br><code>Funktion</code><br></td>
        </tr>
        <tr>
          <td><code>background</code></th>
-         <td><code>Grundlage</code><br></td>
+         <td><code>Grundlage</code><br><code>Hintergrund</code><br><code>Voraussetzungen</code><br><code>Vorbedingungen</code><br></td>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Szenario</code><br></td>
+         <td><code>Beispiel</code><br><code>Szenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
-         <td><code>Szenariogrundriss</code><br></td>
+         <td><code>Szenariogrundriss</code><br><code>Szenarien</code><br></td>
        </tr>
        <tr>
          <td><code>examples</code></th>
@@ -1400,6 +1500,10 @@ German (de)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Aber </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br><code>Regel</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1424,7 +1528,7 @@ Greek (el)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Σενάριο</code><br></td>
+         <td><code>Παράδειγμα</code><br><code>Σενάριο</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1454,6 +1558,10 @@ Greek (el)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Αλλά </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1478,7 +1586,7 @@ Gujarati (gj)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>સ્થિતિ</code><br></td>
+         <td><code>ઉદાહરણ</code><br><code>સ્થિતિ</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1508,6 +1616,10 @@ Gujarati (gj)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>પણ </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1532,7 +1644,7 @@ Hebrew (he)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>תרחיש</code><br></td>
+         <td><code>דוגמא</code><br><code>תרחיש</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1561,6 +1673,10 @@ Hebrew (he)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>אבל </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>כלל</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -1616,6 +1732,10 @@ Hindi (hi)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>पर </code><br><code>परन्तु </code><br><code>किन्तु </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1640,7 +1760,7 @@ Hungarian (hu)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Forgatókönyv</code><br></td>
+         <td><code>Példa</code><br><code>Forgatókönyv</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1669,6 +1789,10 @@ Hungarian (hu)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>De </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -1724,6 +1848,10 @@ Icelandic (is)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>En </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1744,7 +1872,7 @@ Indonesian (id)</a>
        </tr>
        <tr>
          <td><code>background</code></th>
-         <td><code>Dasar</code><br></td>
+         <td><code>Dasar</code><br><code>Latar Belakang</code><br></td>
        </tr>
        <tr>
          <td><code>scenario</code></th>
@@ -1752,15 +1880,15 @@ Indonesian (id)</a>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
-         <td><code>Skenario konsep</code><br></td>
+         <td><code>Skenario konsep</code><br><code>Garis-Besar Skenario</code><br></td>
        </tr>
        <tr>
          <td><code>examples</code></th>
-         <td><code>Contoh</code><br></td>
+         <td><code>Contoh</code><br><code>Misal</code><br></td>
        </tr>
        <tr>
          <td><code>given</code></th>
-         <td><code>* </code><br><code>Dengan </code><br></td>
+         <td><code>* </code><br><code>Dengan </code><br><code>Diketahui </code><br><code>Diasumsikan </code><br><code>Bila </code><br><code>Jika </code><br></td>
        </tr>
        <tr>
          <td><code>when</code></th>
@@ -1768,7 +1896,7 @@ Indonesian (id)</a>
        </tr>
        <tr>
          <td><code>then</code></th>
-         <td><code>* </code><br><code>Maka </code><br></td>
+         <td><code>* </code><br><code>Maka </code><br><code>Kemudian </code><br></td>
        </tr>
        <tr>
          <td><code>and</code></th>
@@ -1776,7 +1904,11 @@ Indonesian (id)</a>
        </tr>
        <tr>
          <td><code>but</code></th>
-         <td><code>* </code><br><code>Tapi </code><br></td>
+         <td><code>* </code><br><code>Tapi </code><br><code>Tetapi </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br><code>Aturan</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -1802,7 +1934,7 @@ Irish (ga)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Cás</code><br></td>
+         <td><code>Sampla</code><br><code>Cás</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1832,6 +1964,10 @@ Irish (ga)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ach</code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1848,7 +1984,7 @@ Italian (it)</a>
      <tbody>
        <tr>
          <td><code>feature</code></th>
-         <td><code>Funzionalità</code><br></td>
+         <td><code>Funzionalità</code><br><code>Esigenza di Business</code><br><code>Abilità</code><br></td>
        </tr>
        <tr>
          <td><code>background</code></th>
@@ -1856,7 +1992,7 @@ Italian (it)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenario</code><br></td>
+         <td><code>Esempio</code><br><code>Scenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -1885,6 +2021,10 @@ Italian (it)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ma </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Regola</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -1940,6 +2080,10 @@ Japanese (ja)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>しかし</code><br><code>但し</code><br><code>ただし</code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -1994,6 +2138,10 @@ Javanese (jv)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Tapi </code><br><code>Nanging </code><br><code>Ananging </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2018,7 +2166,7 @@ Kannada (kn)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>ಕಥಾಸಾರಾಂಶ</code><br></td>
+         <td><code>ಉದಾಹರಣೆ</code><br><code>ಕಥಾಸಾರಾಂಶ</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2047,6 +2195,10 @@ Kannada (kn)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>ಆದರೆ </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -2102,6 +2254,10 @@ Klingon (tlh)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>&apos;ach </code><br><code>&apos;a </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2155,6 +2311,10 @@ Korean (ko)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>하지만</code><br><code>단</code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -2210,6 +2370,10 @@ LOLCAT (en-lol)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>BUT </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2234,7 +2398,7 @@ Latvian (lv)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenārijs</code><br></td>
+         <td><code>Piemērs</code><br><code>Scenārijs</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2264,6 +2428,10 @@ Latvian (lv)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Bet </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2288,7 +2456,7 @@ Lithuanian (lt)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenarijus</code><br></td>
+         <td><code>Pavyzdys</code><br><code>Scenarijus</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2318,6 +2486,10 @@ Lithuanian (lt)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Bet </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2342,7 +2514,7 @@ Luxemburgish (lu)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Szenario</code><br></td>
+         <td><code>Beispill</code><br><code>Szenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2372,6 +2544,10 @@ Luxemburgish (lu)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>awer </code><br><code>mä </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2396,7 +2572,7 @@ Macedonian (mk-Cyrl)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Сценарио</code><br><code>На пример</code><br></td>
+         <td><code>Пример</code><br><code>Сценарио</code><br><code>На пример</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2425,6 +2601,10 @@ Macedonian (mk-Cyrl)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Но </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -2480,6 +2660,10 @@ Macedonian (Latin) (mk-Latn)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>No </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2533,6 +2717,68 @@ Malay (bm)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Tetapi </code><br><code>Tapi </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
+     </tbody>
+   </table>
+  </div>
+  <a class="panel-block" data-target="#gherkin-dialect-mr-content">
+Marathi (mr)</a>
+  <div id="gherkin-dialect-mr-content" class="panel-block collapsed">
+   <table class="table is-size-6">
+     <thead>
+      <tr>
+       <th>English Keyword</th>
+       <th>Marathi equivalent(s)</th>
+      </tr>
+     </thead>
+     <tbody>
+       <tr>
+         <td><code>feature</code></th>
+         <td><code>वैशिष्ट्य</code><br><code>सुविधा</code><br></td>
+       </tr>
+       <tr>
+         <td><code>background</code></th>
+         <td><code>पार्श्वभूमी</code><br></td>
+       </tr>
+       <tr>
+         <td><code>scenario</code></th>
+         <td><code>परिदृश्य</code><br></td>
+       </tr>
+       <tr>
+         <td><code>scenarioOutline</code></th>
+         <td><code>परिदृश्य रूपरेखा</code><br></td>
+       </tr>
+       <tr>
+         <td><code>examples</code></th>
+         <td><code>उदाहरण</code><br></td>
+       </tr>
+       <tr>
+         <td><code>given</code></th>
+         <td><code>* </code><br><code>जर</code><br><code>दिलेल्या प्रमाणे </code><br></td>
+       </tr>
+       <tr>
+         <td><code>when</code></th>
+         <td><code>* </code><br><code>जेव्हा </code><br></td>
+       </tr>
+       <tr>
+         <td><code>then</code></th>
+         <td><code>* </code><br><code>मग </code><br><code>तेव्हा </code><br></td>
+       </tr>
+       <tr>
+         <td><code>and</code></th>
+         <td><code>* </code><br><code>आणि </code><br><code>तसेच </code><br></td>
+       </tr>
+       <tr>
+         <td><code>but</code></th>
+         <td><code>* </code><br><code>पण </code><br><code>परंतु </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>नियम</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -2588,6 +2834,68 @@ Mongolian (mn)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Гэхдээ </code><br><code>Харин </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
+     </tbody>
+   </table>
+  </div>
+  <a class="panel-block" data-target="#gherkin-dialect-ne-content">
+Nepali (ne)</a>
+  <div id="gherkin-dialect-ne-content" class="panel-block collapsed">
+   <table class="table is-size-6">
+     <thead>
+      <tr>
+       <th>English Keyword</th>
+       <th>Nepali equivalent(s)</th>
+      </tr>
+     </thead>
+     <tbody>
+       <tr>
+         <td><code>feature</code></th>
+         <td><code>सुविधा</code><br><code>विशेषता</code><br></td>
+       </tr>
+       <tr>
+         <td><code>background</code></th>
+         <td><code>पृष्ठभूमी</code><br></td>
+       </tr>
+       <tr>
+         <td><code>scenario</code></th>
+         <td><code>परिदृश्य</code><br></td>
+       </tr>
+       <tr>
+         <td><code>scenarioOutline</code></th>
+         <td><code>परिदृश्य रूपरेखा</code><br></td>
+       </tr>
+       <tr>
+         <td><code>examples</code></th>
+         <td><code>उदाहरण</code><br><code>उदाहरणहरु</code><br></td>
+       </tr>
+       <tr>
+         <td><code>given</code></th>
+         <td><code>* </code><br><code>दिइएको </code><br><code>दिएको </code><br><code>यदि </code><br></td>
+       </tr>
+       <tr>
+         <td><code>when</code></th>
+         <td><code>* </code><br><code>जब </code><br></td>
+       </tr>
+       <tr>
+         <td><code>then</code></th>
+         <td><code>* </code><br><code>त्यसपछि </code><br><code>अनी </code><br></td>
+       </tr>
+       <tr>
+         <td><code>and</code></th>
+         <td><code>* </code><br><code>र </code><br><code>अनी </code><br></td>
+       </tr>
+       <tr>
+         <td><code>but</code></th>
+         <td><code>* </code><br><code>तर </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>नियम</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2612,7 +2920,7 @@ Norwegian (no)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenario</code><br></td>
+         <td><code>Eksempel</code><br><code>Scenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2641,6 +2949,10 @@ Norwegian (no)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Men </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Regel</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -2696,6 +3008,10 @@ Old English (en-old)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ac </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2720,7 +3036,7 @@ Panjabi (pa)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>ਪਟਕਥਾ</code><br></td>
+         <td><code>ਉਦਾਹਰਨ</code><br><code>ਪਟਕਥਾ</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2750,6 +3066,10 @@ Panjabi (pa)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>ਪਰ </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2774,7 +3094,7 @@ Persian (fa)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>سناریو</code><br></td>
+         <td><code>مثال</code><br><code>سناریو</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2803,6 +3123,10 @@ Persian (fa)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>اما </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -2858,6 +3182,10 @@ Pirate (en-pirate)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Avast! </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2882,7 +3210,7 @@ Polish (pl)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenariusz</code><br></td>
+         <td><code>Przykład</code><br><code>Scenariusz</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2912,6 +3240,10 @@ Polish (pl)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ale </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2936,7 +3268,7 @@ Portuguese (pt)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Cenário</code><br><code>Cenario</code><br></td>
+         <td><code>Exemplo</code><br><code>Cenário</code><br><code>Cenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -2966,6 +3298,10 @@ Portuguese (pt)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Mas </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Regra</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -2990,7 +3326,7 @@ Romanian (ro)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenariu</code><br></td>
+         <td><code>Exemplu</code><br><code>Scenariu</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3020,6 +3356,10 @@ Romanian (ro)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Dar </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3044,7 +3384,7 @@ Russian (ru)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Сценарий</code><br></td>
+         <td><code>Пример</code><br><code>Сценарий</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3132,6 +3472,10 @@ Scouse (en-Scouse)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Buh </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3156,7 +3500,7 @@ Serbian (sr-Cyrl)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Сценарио</code><br><code>Пример</code><br></td>
+         <td><code>Пример</code><br><code>Сценарио</code><br><code>Пример</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3185,6 +3529,10 @@ Serbian (sr-Cyrl)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Али </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -3240,6 +3588,10 @@ Serbian (Latin) (sr-Latn)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ali </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3264,7 +3616,7 @@ Slovak (sk)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenár</code><br></td>
+         <td><code>Príklad</code><br><code>Scenár</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3294,6 +3646,10 @@ Slovak (sk)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ale </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3318,7 +3674,7 @@ Slovenian (sl)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenarij</code><br><code>Primer</code><br></td>
+         <td><code>Primer</code><br><code>Scenarij</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3348,6 +3704,10 @@ Slovenian (sl)</a>
          <td><code>but</code></th>
          <td><code>Toda </code><br><code>Ampak </code><br><code>Vendar </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3372,7 +3732,7 @@ Spanish (es)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Escenario</code><br></td>
+         <td><code>Ejemplo</code><br><code>Escenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3401,6 +3761,10 @@ Spanish (es)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Pero </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Regla</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -3456,6 +3820,10 @@ Swedish (sv)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Men </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Regel</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3480,7 +3848,7 @@ Tamil (ta)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>காட்சி</code><br></td>
+         <td><code>உதாரணமாக</code><br><code>காட்சி</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3488,7 +3856,7 @@ Tamil (ta)</a>
        </tr>
        <tr>
          <td><code>examples</code></th>
-         <td><code>எடுத்துக்காட்டுகள்</code><br><code>காட்சிகள்</code><br><code> நிலைமைகளில்</code><br></td>
+         <td><code>எடுத்துக்காட்டுகள்</code><br><code>காட்சிகள்</code><br><code>நிலைமைகளில்</code><br></td>
        </tr>
        <tr>
          <td><code>given</code></th>
@@ -3509,6 +3877,10 @@ Tamil (ta)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>ஆனால்  </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -3564,12 +3936,16 @@ Tatar (tt)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ләкин </code><br><code>Әмма </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
-  <a class="panel-block" data-target="#gherkin-dialect-tl-content">
-Telugu (tl)</a>
-  <div id="gherkin-dialect-tl-content" class="panel-block collapsed">
+  <a class="panel-block" data-target="#gherkin-dialect-te-content">
+Telugu (te)</a>
+  <div id="gherkin-dialect-te-content" class="panel-block collapsed">
    <table class="table is-size-6">
      <thead>
       <tr>
@@ -3588,7 +3964,7 @@ Telugu (tl)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>సన్నివేశం</code><br></td>
+         <td><code>ఉదాహరణ</code><br><code>సన్నివేశం</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3617,6 +3993,10 @@ Telugu (tl)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>కాని </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -3672,6 +4052,10 @@ Thai (th)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>แต่ </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3696,7 +4080,7 @@ Turkish (tr)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Senaryo</code><br></td>
+         <td><code>Örnek</code><br><code>Senaryo</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3726,6 +4110,10 @@ Turkish (tr)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Fakat </code><br><code>Ama </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3750,7 +4138,7 @@ Ukrainian (uk)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Сценарій</code><br></td>
+         <td><code>Приклад</code><br><code>Сценарій</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3779,6 +4167,10 @@ Ukrainian (uk)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Але </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -3834,6 +4226,10 @@ Urdu (ur)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>لیکن </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3887,6 +4283,10 @@ Uzbek (uz)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Лекин </code><br><code>Бирок </code><br><code>Аммо </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>
@@ -3942,6 +4342,10 @@ Vietnamese (vi)</a>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Nhưng </code><br></td>
        </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
+       </tr>
      </tbody>
    </table>
   </div>
@@ -3966,7 +4370,7 @@ Welsh (cy-GB)</a>
        </tr>
        <tr>
          <td><code>scenario</code></th>
-         <td><code>Scenario</code><br></td>
+         <td><code>Enghraifft</code><br><code>Scenario</code><br></td>
        </tr>
        <tr>
          <td><code>scenarioOutline</code></th>
@@ -3995,6 +4399,10 @@ Welsh (cy-GB)</a>
        <tr>
          <td><code>but</code></th>
          <td><code>* </code><br><code>Ond </code><br></td>
+       </tr>
+       <tr>
+         <td><code>rule</code></th>
+         <td><code>Rule</code><br></td>
        </tr>
      </tbody>
    </table>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "algolia": "atomic-algolia"
   },
   "dependencies": {
-    "gherkin": "9.0.0"
+    "@cucumber/gherkin": "latest"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@cucumber/gherkin@latest":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin/-/gherkin-17.0.2.tgz#c6644ecb5c2c4671360d9e5affa2a00e7897ab78"
+  integrity sha512-U8ZxbYVLEXqUy4Fx9BJ5ncIzXz/eVg+fKV2F8B1t5f6eDMgPQ2Aq3M8gy3yE422OAuJ+RFRuezNtuEbpmf2r4g==
+  dependencies:
+    "@cucumber/messages" "^14.0.1"
+    commander "^7.1.0"
+    source-map-support "^0.5.19"
+
+"@cucumber/messages@^14.0.1":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-14.0.1.tgz#cb2abaa64bd9b4a3ddf0913ff17cafe5b901051c"
+  integrity sha512-uCD/yP7P5em0KP1r59x6JayAxH7n8QXU9FbC3H8XMosZuM9z4PVLeU5pdJRkkCLFXqjpAZ3LJw65hlYDrBujEQ==
+  dependencies:
+    "@types/uuid" "^8.3.0"
+    protobufjs "^6.10.2"
+    uuid "^8.3.2"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -61,52 +79,34 @@
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
 "@types/node@^13.7.0":
-  version "13.13.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.16.tgz#66f2177047b61131eaac18c47eb25d6f1317070a"
-  integrity sha512-dJ9vXxJ8MEwzNn4GkoAGauejhXoKuJyYKegsA6Af25ZpEDXomeVXt5HUWUNVHk5UN7+U0f6ghC6otwt+7PdSDg==
+  version "13.13.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.45.tgz#e6676bcca092bae5751d015f074a234d5a82eb63"
+  integrity sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow==
 
-"@types/uuid@^3.4.6":
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
-  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-commander@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
-cucumber-messages@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cucumber-messages/-/cucumber-messages-8.0.0.tgz#99766ffe026185798eb80fc8c720d60d8a6ac8cb"
-  integrity sha512-lUnWRMjwA9+KhDec/5xRZV3Du67ISumHnVLywWQXyvzmc4P+Eqx8CoeQrBQoau3Pw1hs4kJLTDyV85hFBF00SQ==
-  dependencies:
-    "@types/uuid" "^3.4.6"
-    protobufjs "^6.8.8"
-    uuid "^3.3.3"
-
-gherkin@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/gherkin/-/gherkin-9.0.0.tgz#dc1e52bb495f712f6de8f495eb7a2b655cbbabfd"
-  integrity sha512-6xoAepoxo5vhkBXjB4RCfVnSKHu5z9SqXIQVUyj+Jw8BQX8odATlee5otXgdN8llZvyvHokuvNiBeB3naEnnIQ==
-  dependencies:
-    commander "^4.0.1"
-    cucumber-messages "8.0.0"
-    source-map-support "^0.5.16"
+commander@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
+  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
 
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-protobufjs@^6.8.8:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.1.tgz#e6a484dd8f04b29629e9053344e3970cccf13cd2"
-  integrity sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==
+protobufjs@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.2.tgz#b9cb6bd8ec8f87514592ba3fdfd28e93f33a469b"
+  integrity sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -122,7 +122,7 @@ protobufjs@^6.8.8:
     "@types/node" "^13.7.0"
     long "^4.0.0"
 
-source-map-support@^0.5.16:
+source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -135,7 +135,7 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-uuid@^3.3.3:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
The gherkin Internationalization table missed some updates for some time.

The automation to generate it was still relying on the old npm `gherkin@9.0` package, before the `rule` keyword.

I've also added a README.md to explain how to update the table automatically.