### PR TITLE
Fix link text to point to Jython archived project

### DIFF
--- a/content/docs/installation/jython.md
+++ b/content/docs/installation/jython.md
@@ -8,4 +8,4 @@ weight: 1312
 
 **This package is currently in need of new maintainers.**
 
-Please see [Cucumber-JRuby](https://github.com/cucumber/cucumber-jvm-jython).
+Please see [Cucumber-Jython](https://github.com/cucumber/cucumber-jvm-jython).


### PR DESCRIPTION
The link was typo'd.