### PR TITLE
Fix for #622 by copying the corresponding documentation from the Gher…

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -480,6 +480,14 @@ Given the following users exist:
 ```
 Just like `Doc Strings`, `Data Tables` will be passed to the step definition as the last argument.
 
+### Table Cell Escaping
+
+If you want to use a newline character in a table cell, you can write this
+as `\n`. If you need a `|` as part of the cell, you can escape it as `\|`. And
+finally, if you need a `\`, you can escape that with `\\`.
+
+### Data Table API
+
 Cucumber provides a rich API for manipulating tables from within step definitions.
 See the [Data Table API reference](https://github.com/cucumber/cucumber/tree/master/datatable) reference for
 more details.


### PR DESCRIPTION
…kin specification.

I have considered whether I should add a comment in the Markdown source that the text is copied from https://github.com/cucumber/common/blob/main/gherkin/README.md, and whether I should also change that file to mention that this new section in the documentation exists, so that somebody who updates the Gherkin specification can be aware of this section in the documentation.

I have not done this because I could not find similar instances of such comment references in those sections of the documentation that I have looked at. But I'm happy to change the PR to include such comments if desired.