### PR TITLE
Add `tags` example for `Scenario Outline`

### DIFF
--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -690,13 +690,13 @@ Scenario Outline: Steps will run conditionally if tagged
 
   @mobile
   Examples: 
-  | link |
-  | logout link on mobile |
+    | link                  |
+    | logout link on mobile |
 
   @desktop
   Examples:
-  | link |
-  | logout link on desktop |
+    | link                   |
+    | logout link on desktop |
 ```
 
 It is *not* possible to place tags above `Background` or steps (`Given`, `When`, `Then`, `And` and `But`).

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -680,6 +680,25 @@ Tags can be placed above the following Gherkin elements:
 * `Scenario Outline`
 * `Examples`
 
+In `Scenario Outline`, you can use tags on different example like below:
+
+```gherkin
+Scenario Outline: Steps will run conditionally if tagged
+  Given user is logged in
+  When user clicks <link>
+  Then user will be logged out
+
+  @mobile
+  Examples: 
+  | link |
+  | logout link on mobile |
+
+  @desktop
+  Examples:
+  | link |
+  | logout link on desktop |
+```
+
 It is *not* possible to place tags above `Background` or steps (`Given`, `When`, `Then`, `And` and `But`).
 
 ## Tag Inheritance


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

It was not clear in the docs for how to tag the `Scenario Outline`'s `Examples`. After figured it out from https://stackoverflow.com/a/41278019/1212791, I would like to add this to the doc.

# Motivation & context

Improve the documentation.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
