### PR TITLE
cucumber-js now supports BeforeStep and AfterStep hooks

### DIFF
--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -425,7 +425,7 @@ end
 {{% block "javascript" %}}Cucumber.js does not support `Around` hooks.{{% /block %}}
 
 ## Step hooks
-{{% text "java,kotlin,scala" %}}
+{{% text "java,kotlin,scala,javascript" %}}
 Step hooks invoked before and after a step. The hooks have 'invoke around' semantics. Meaning that if a `BeforeStep`
 hook is executed the `AfterStep` hooks will also be executed regardless of the result of the step. If a step did not
 pass, the following step and its hooks will be skipped.
@@ -469,7 +469,13 @@ BeforeStep { scenario: Scenario =>
 ```
 {{% /text %}}
 
-{{% text "javascript" %}}Cucumber.js does not support `BeforeStep` hooks.{{% /text %}}
+{{% text "javascript" %}}
+```javascript
+BeforeStep(function(scenario) {
+    // doSomething
+})
+```
+{{% /text %}}
 
 ### AfterStep
 
@@ -516,7 +522,13 @@ AfterStep { scenario: Scenario =>
 
 {{% /block %}}
 
-{{% block "javascript" %}}Cucumber.js does not support `AfterStep` hooks.{{% /block %}}
+{{% block "javascript" %}}
+```javascript
+AfterStep(function(scenario) {
+    // doSomething
+})
+```
+{{% /block %}}
 
 ## Conditional hooks
 

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -471,8 +471,12 @@ BeforeStep { scenario: Scenario =>
 
 {{% text "javascript" %}}
 ```javascript
-BeforeStep(function(scenario) {
+BeforeStep(function({pickle, pickleStep, gherkinDocument, testCaseStartedId, testStepId}) {
     // doSomething
+})
+
+BeforeStep({tags: "@foo"}, function() {
+    // apply this hook to only specific scenarios
 })
 ```
 {{% /text %}}
@@ -524,7 +528,7 @@ AfterStep { scenario: Scenario =>
 
 {{% block "javascript" %}}
 ```javascript
-AfterStep(function(scenario) {
+AfterStep(function({pickle, pickleStep, gherkinDocument, result, testCaseStartedId, testStepId}) {
     // doSomething
 })
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

BeforeStep and AfterStep hooks were added in cucumber-js version [7.0.0](https://github.com/cucumber/cucumber-js/blob/main/CHANGELOG.md#700-2020-12-21). This feature was added in this [merge request](https://github.com/cucumber/cucumber-js/pull/1416) and documentation was not updated. This PR fixes docs about javascript and cucumber-js.

# Motivation & context

Documentation is misleading and outdated.

## Type of change

- Refactoring/debt update docs

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
