### PR TITLE
Set npm link to specific package page

### DIFF
--- a/content/docs/installation/javascript.md
+++ b/content/docs/installation/javascript.md
@@ -13,7 +13,7 @@ Watch the Cucumber School video lesson on installing Cucumber.js [here](https://
 
 ----
 
-Cucumber.js is available as an [NPM](https://www.npmjs.com) module. It works with both [Node.js](https://nodejs.org/en/) and browsers.
+Cucumber.js is available as an [npm module](https://www.npmjs.com/package/@cucumber/cucumber). It works with both [Node.js](https://nodejs.org/en/) and browsers.
 
 # With Node.js
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I changed the link in the documentation to the specific cucumber.js package.

# Motivation & context

It helps exploring the package on npm and it's README.

## Type of change

<!--- Delete any options that are not relevant -->

- UX / DX optimization

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
