### PR TITLE
Gherkin reference: fix broken link

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -490,7 +490,7 @@ finally, if you need a `\`, you can escape that with `\\`.
 ### Data Table API
 
 Cucumber provides a rich API for manipulating tables from within step definitions.
-See the [Data Table API reference](https://github.com/cucumber/cucumber/tree/master/datatable) reference for
+See the [Data Table API reference](https://github.com/cucumber/cucumber-jvm/tree/main/datatable) reference for
 more details.
 
 # Spoken Languages


### PR DESCRIPTION

# Description

Fix broken link.

# Motivation & context

As it turns out, the datatable subproject has been recently moved from cucumber/common to cucumber-jvm.

See https://github.com/cucumber/common/pull/1744

