### PR TITLE
Update `.wait_until_present method` to `.wait_until` in the Watir Web Automation example throws an error

### DIFF
--- a/content/docs/guides/browser-automation.md
+++ b/content/docs/guides/browser-automation.md
@@ -220,7 +220,7 @@ describe "google.com" do
   before { browser.goto "http://google.com" }
   browser.text_field(name: "q").set "watir"
   browser.button.click
-  browser.div(id: "resultStats").wait_until_present
+  browser.div(id: "resultStats").wait_until
   browser.title.should == "watir - Google Search"
   after { browser.close }
 end


### PR DESCRIPTION
Update `.wait_until_present method` to `.wait_until` in the Watir Web Automation example throws an error

<!--- Provide a general summary of your changes in the Title above -->

# Description

According to Watir's documentation "As of 6.15 `#wait_while_present` and `#wait_until_present` are deprecated." When I use`#wait_until` instead, it works fine.

Reference: [Watir guides](http://watir.com/guides/waiting/)


# Motivation & context

When I executed the Watir web automation example I got a `NoMethodError` error that stated "undefined method `wait_until_present' for #<Watir::Div: located: false; {:id=>"resultStats", :tag_name=>"div"}>"

I'm not sure if there is an open issue for this.


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Update required of cucumber.io/docs

_If the [Cucumber documentation](https://cucumber.io/docs/) will require an update,
submit an issue or ideally a pull request to [cucumber/docs](https://github.com/cucumber/docs/) and
reference it here._

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
