### PR TITLE
remove reference to strict option

### DIFF
--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -1339,49 +1339,6 @@ class RunCucumberTest {
 
 The default option for `monochrome` is `false`.
 
-**Skip undefined tests:**
-
-For example if you want to skip undefined steps from execution, you can specify it like this:
-
-```java
-package com.example;
-
-import io.cucumber.junit.Cucumber;
-import io.cucumber.junit.CucumberOptions;
-import org.junit.runner.RunWith;
-
-@RunWith(Cucumber.class)
-@CucumberOptions(strict=false)
-public class RunCucumberTest {
-}
-```
-
-```kotlin
-package com.example
-
-import io.cucumber.junit.Cucumber
-import io.cucumber.junit.CucumberOptions
-import org.junit.runner.RunWith
-
-@RunWith(Cucumber.class)
-@CucumberOptions(strict=false)
-class RunCucumberTest
-```
-
-```scala
-package com.example;
-
-import io.cucumber.junit.Cucumber;
-import io.cucumber.junit.CucumberOptions;
-import org.junit.runner.RunWith;
-
-@RunWith(Cucumber.class)
-@CucumberOptions(strict=false)
-class RunCucumberTest {
-}
-```
-The default option for `strict` is `true`.
-
 **Select scenarios using tags:**
 
 For example if you want to tell Cucumber to only run the scenarios specified with specific tags, you can specify it like this:


### PR DESCRIPTION
# Description

Removed 'Skip undefined tests' section

# Motivation & context

Strict option was removed in cucumber 7, see https://github.com/cucumber/cucumber-jvm/pull/2275

## Type of change

Doc fix.

# Checklist:

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
