### PR TITLE
Update browser-automation.md

### DIFF
--- a/content/docs/guides/browser-automation.md
+++ b/content/docs/guides/browser-automation.md
@@ -289,7 +289,7 @@ To take a screenshot on failure, you can configure an [after hook](/docs/cucumbe
 
 {{% block "java,javascript,kotlin" %}}
 Below is an example of how to take a screenshot with
-[WebDriver](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/TakesScreenshot.html)
+[WebDriver](https://www.selenium.dev/documentation/webdriver/browser/windows/#takescreenshot)
 for failed scenarios and embed them in Cucumber's report.
 {{% /block %}}
 


### PR DESCRIPTION
Replace a link to specific Java documentation with a generic one

<!---
Thanks for submitting a pull request!

The prompts below (the _bits in italics_) are for guidance to help you describe your change in a way that is most likely to make sense to other people when they are reviewing it. Still, it's just a guide, so feel free to delete anything that doesn't feel appropriate, and add anything additional that seems like it would probide useful context.

Please either replace the promopts with your own words, or delete them.
-->

# Description

One link to new WebDriver documentation was a direct link to some java API. I replace it with a multilanguage one

