### PR TITLE
cucumber.execution.strict is no longer supported

### DIFF
--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -130,11 +130,11 @@ When Cucumber finds a matching step definition it will execute it. If the block 
 
 #### Undefined
 
-When Cucumber can't find a matching step definition, the step gets marked as undefined (yellow), and all subsequent steps in the scenario are skipped. If you use `--strict`, this will cause Cucumber to exit with `1`.
+When Cucumber can't find a matching step definition, the step gets marked as undefined (yellow), and all subsequent steps in the scenario are skipped.
 
 #### Pending
 
-When a step definition's method or function invokes the `pending` method, the step is marked as pending (yellow, as with `undefined` ones), indicating that you have work to do. If you use `--strict`, this will cause Cucumber to exit with `1`.
+When a step definition's method or function invokes the `pending` method, the step is marked as pending (yellow, as with `undefined` ones), indicating that you have work to do.
 
 #### Failed Steps
 
@@ -1535,7 +1535,6 @@ cucumber.ansi-colors.disabled=  # true or false. default: false
 cucumber.execution.dry-run=     # true or false. default: false
 cucumber.execution.limit=       # number of scenarios to execute (CLI only).
 cucumber.execution.order=       # lexical, reverse, random or random:[seed] (CLI only). default: lexical
-cucumber.execution.strict=      # true or false. default: true.
 cucumber.execution.wip=         # true or false. default: false.
 cucumber.features=              # comma separated paths to feature files. example: path/to/example.feature, path/to/other.feature
 cucumber.filter.name=           # regex. example: .*Hello.*


### PR DESCRIPTION
At least, the option is [no longer supported by cucumber-jvm](https://github.com/cucumber/cucumber-jvm/commit/71bb1cc411e2bcd0b7d698e51c1de28eced419e5).

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request 
if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here 
to help and will coach you through to getting your pull 
request ready to merge.

The prompts below are for guidance to help you describe 
your change in a way that is most likely to make sense 
to other people when they are reviewing it. Still, it's 
just a guide, so feel free to delete anything that 
doesn't feel appropriate, and add anything additional 
that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

Remove references to `strict` CLI options and properties

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change?

If it's related to another issue or bugfix, add it as a reference here, 
e.g. "Fixes cucumber/cucumber-js#99"
-->

https://github.com/cucumber/cucumber-jvm/pull/2275

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
