### PR TITLE
#760 changing to the correct CSS class name

### DIFF
--- a/themes/cucumber-hugo/layouts/shortcodes/warn.html
+++ b/themes/cucumber-hugo/layouts/shortcodes/warn.html
@@ -1,4 +1,4 @@
-<article class="message is-danger">
+<article class="message is-warning">
   <div class="message-header">
     <p>{{ .Get 0 }}</p>
   </div>


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request 
if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here 
to help and will coach you through to getting your pull 
request ready to merge.

The prompts below are for guidance to help you describe 
your change in a way that is most likely to make sense 
to other people when they are reviewing it. Still, it's 
just a guide, so feel free to delete anything that 
doesn't feel appropriate, and add anything additional 
that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->
CSS class name `is-danger` is replaced with `is-warning` in `danger.html in themes/cucumber-hugo/layouts/shortcodes/ `

### ⚡️ What's your motivation? 
Making the look and feel more consistent.
<!-- 
What motivated you to propose this change?

If it's related to another issue or bugfix, add it as a reference here, 
e.g. "Fixes cucumber/cucumber-js#99"
-->

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
