### PR TITLE
Update links to Cucumber JVM

### DIFF
--- a/content/docs/community/faq.md
+++ b/content/docs/community/faq.md
@@ -77,11 +77,11 @@ For information on how to run the Cucumber CLI, see [From the command line](/doc
 For information about configuration options, see [Configuration](/docs/cucumber/configuration/).
 
 {{% block "java,kotlin" %}}
-When using JUnit 5, reference the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine).
+When using JUnit 5, reference the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine).
 
 When running Cucumber with JUnit 4, you can specify several options on how JUnit 4 should run your tests.
 Check the section on [JUnit](https://docs.cucumber.io/cucumber/api/#junit) for more information. For more
-details about the available CucumberOptions, check the [code](https://github.com/cucumber/cucumber-jvm/blob/main/core/src/test/java/io/cucumber/core/options/CucumberOptions.java).
+details about the available CucumberOptions, check the [code](https://github.com/cucumber/cucumber-jvm/blob/main/cucumber-junit/src/main/java/io/cucumber/junit/CucumberOptions.java).
 
 
 {{% /block %}}
@@ -142,11 +142,11 @@ You can find the required dependencies [here](https://docs.cucumber.io/installat
 {{% /block %}}
 
 {{% block "java" %}}
-For an example on how to use them, see this [code example](https://github.com/cucumber/cucumber-jvm/blob/main/examples/java8-calculator/src/test/java/io/cucumber/examples/java8/RpnCalculatorSteps.java).
+For an example on how to use them, see this [code example](https://github.com/cucumber/cucumber-jvm/blob/main/examples/calculator-java8-cli/src/test/java/io/cucumber/examples/calculator/RpnCalculatorSteps.java).
 {{% /block %}}
 
 {{% block "kotlin" %}}
-For an example on how to use them, see this [code example](https://github.com/cucumber/cucumber-jvm/blob/main/kotlin-java8/src/test/kotlin/io/cucumber/kotlin/LambdaStepDefinitions.kt).
+For an example on how to use them, see this [code example](https://github.com/cucumber/cucumber-jvm/blob/main/cucumber-kotlin-java8/src/test/kotlin/io/cucumber/kotlin/LambdaStepDefinitions.kt).
 {{% /block %}}
 
 ## How do I call other steps or scenarios?
@@ -254,7 +254,7 @@ multiple steps might match the same expression. Finally, this means that you can
 definitions, as that will lead to duplicates.
 
 # Does Cucumber-JVM support Kotlin?
-You can use [Cucumber-JVM](https://github.com/cucumber/cucumber-jvm) to write step definitions in Kotlin. Please have a look at the [Kotlin examples for cucumber-jvm](https://github.com/cucumber/cucumber-jvm/tree/master/kotlin-java8). 
+You can use [Cucumber-JVM](https://github.com/cucumber/cucumber-jvm) to write step definitions in Kotlin. Please have a look at the [Kotlin examples for cucumber-jvm](https://github.com/cucumber/cucumber-jvm/tree/master/cucumber-kotlin-java8). 
 At the moment it is not possible to generate step definitions in Kotlin. The reason for this is that there is no Kotlin Backend implemented. If this is something you'd like to work on, there is [a request for one](https://github.com/cucumber/cucumber-jvm/issues/1520). There is also a request for a [native Kotlin implementation of Cucumber](https://github.com/cucumber/cucumber/issues/331).
 
 # Cucumber can't find my step definitions in IntelliJ IDEA

--- a/content/docs/community/not-cucumber.md
+++ b/content/docs/community/not-cucumber.md
@@ -113,7 +113,7 @@ For more information see the [Karate project on GitHub](https://github.com/intui
 {{% text "java,kotlin" %}}
 If you are having issues when using TestNG with Cucumber-JVM, please check that you are using the version of TestNG that Cucumber-JVM was build against.
 
-For an example of how to use TestNG with Cucumber, see the [java-calculator-testng example](https://github.com/cucumber/cucumber-jvm/tree/main/examples/java-calculator-testng).
+For an example of how to use TestNG with Cucumber, see the [java-calculator-testng example](https://github.com/cucumber/cucumber-jvm/tree/main/examples/calculator-java-testng).
 {{% /text %}}
 
 {{% text "ruby,javascript" %}}TestNG is only available for Java and Kotlin.{{% /text %}}

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -88,7 +88,7 @@ See [Github](https://github.com/cucumber/cucumber-jvm-scala/issues/50).
 [here](https://github.com/cucumber/cucumber-js/blob/master/src/models/data_table.ts) {{% /text %}}
 
 {{% text "java,kotlin" %}}In addition, see
-[cucumber-jvm data-tables](https://github.com/cucumber/cucumber-jvm/tree/main/java#data-tables){{% /text %}}
+[cucumber-jvm data-tables](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-java#data-tables){{% /text %}}
 
 # Steps
 
@@ -812,7 +812,7 @@ Tags that are placed above a `Scenario Outline` will be inherited by `Examples`.
 You can tell Cucumber to only run scenarios with a particular tag:
 
 {{% block "java,kotlin,scala" %}}
-For JUnit 5 see the [cucumber-junit-platform-engine documetation](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine#tags).
+For JUnit 5 see the [cucumber-junit-platform-engine documetation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#tags).
 
 For JUnit 4 and TestNG using a JVM system property:
 
@@ -1113,7 +1113,7 @@ You can also run features using a [build tool](/docs/tools/general#build-tools) 
 ## JUnit 5 
 
 {{% block "java,kotlin,scala" %}}
-See the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine#configuration-options)
+See the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#configuration-options)
 {{% /block %}}
 
 {{% block "ruby" %}}
@@ -1141,7 +1141,7 @@ To use JUnit to execute cucumber scenarios add the `cucumber-junit` dependency t
   [...]
 </dependencies>
 ```
-Note that `cucumber-junit` is based on JUnit 4. If you're using JUnit 5, use the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine).
+Note that `cucumber-junit` is based on JUnit 4. If you're using JUnit 5, use the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine).
 Or include `junit-vintage-engine` dependency, as well. For more information, please refer to [JUnit 5 documentation](https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4-running).
 
 Create an empty class that uses the Cucumber JUnit runner.
@@ -1555,7 +1555,7 @@ properties file and CLI arguments take precedence over all.
 
 Note that the `cucumber-junit-platform-engine` is provided with properties
 by the Junit Platform rather than Cucumber. See
-[junit-platform-engine Configuration Options](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine#configuration-options)
+[junit-platform-engine Configuration Options](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#configuration-options)
 for more information.
 
 For example, if you are using Maven and want to run a subset of scenarios tagged

--- a/content/docs/cucumber/checking-assertions.md
+++ b/content/docs/cucumber/checking-assertions.md
@@ -13,7 +13,7 @@ from a unit testing tool.
 
 ## JUnit 5
 
-When using the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine)
+When using the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine)
 you are free to use any assertion library of your choice. For example:
 
  * [AssertJ](https://assertj.github.io/doc/)

--- a/content/docs/cucumber/state.md
+++ b/content/docs/cucumber/state.md
@@ -147,7 +147,7 @@ Or, if you are using Gradle, add:
 compile group: 'io.cucumber', name: 'cucumber-picocontainer', version: '{{% version "cucumberjvm" %}}'
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/picocontainer).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-picocontainer).
 For more information, please see [sharing state using PicoContainer](http://www.thinkcode.se/blog/2017/04/01/sharing-state-between-steps-in-cucumberjvm-using-picocontainer).
 {{% /block %}}
 
@@ -172,7 +172,7 @@ Or, if you are using Gradle, add:
 compile group: 'io.cucumber', name: 'cucumber-spring', version: '{{% version "cucumberjvm" %}}'
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/spring).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-spring).
 {{% /block %}}
 
 {{% block "ruby,javascript" %}} Spring is a Dependency Injection framework for JVM languages. {{% /block %}}
@@ -195,7 +195,7 @@ Or, if you are using Gradle, add:
 compile group: 'io.cucumber', name: 'cucumber-guice', version: '{{% version "cucumberjvm" %}}'
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/guice).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-guice).
 For more information, please see [sharing state using Guice](http://www.thinkcode.se/blog/2017/08/16/sharing-state-between-steps-in-cucumberjvm-using-guice).
 {{% /block %}}
 
@@ -219,7 +219,7 @@ Or, if you are using Gradle, add:
 compile group: 'io.cucumber', name: 'cucumber-openejb', version: '{{% version "cucumberjvm" %}}'
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/openejb).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-openejb).
 {{% /block %}}
 
 {{% block "ruby,javascript" %}} OpenEJB is a Dependency Injection framework for JVM languages. {{% /block %}}
@@ -242,7 +242,7 @@ Or, if you are using Gradle, add:
 compile group: 'io.cucumber', name: 'cucumber-weld', version: '{{% version "cucumberjvm" %}}'
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/weld).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-weld).
 {{% /block %}}
 
 {{% block "ruby,javascript" %}} Weld is a Dependency Injection framework for JVM languages. {{% /block %}}
@@ -265,7 +265,7 @@ Or, if you are using Gradle, add:
 compile group: 'io.cucumber', name: 'cucumber-needle', version: '{{% version "cucumberjvm" %}}'
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/needle).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-needle).
 {{% /block %}}
 
 {{% block "ruby,javascript" %}} Needle is a Dependency Injection framework for JVM languages. {{% /block %}}
@@ -441,7 +441,7 @@ cucumber.object-factory=com.example.app.CustomObjectFactory
 ### Using the Cucumber object factory with a test runner (JUnit 5/JUnit 4/TestNG)
 {{% block "java,kotlin" %}} 
 The Cucumber modules for [JUnit 4](/docs/cucumber/api/#junit) and [TestNG](/docs/cucumber/checking-assertions/#testng) allow to run Cucumber through a JUnit/TestNG test.
-The custom object factory can be configured using the `@CucumberOptions` annotation. For JUnit 5 see the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine) documentation.
+The custom object factory can be configured using the `@CucumberOptions` annotation. For JUnit 5 see the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine) documentation.
 {{% /block %}}
 
 {{% block "ruby,javascript" %}} Using the Cucumber object factory is specific to JVM languages. {{% /block %}}
@@ -489,7 +489,7 @@ Feature: Let's write a lot of stuff to the DB
 
 ### With JUnit 5 and Spring
 {{% block "java,kotlin" %}} 
-See the [`spring-txn`](https://github.com/cucumber/cucumber-jvm/tree/main/examples/spring-java-junit5) example in Cucumber-JVM for a minimal setup.
+See the [`spring-java-junit5`](https://github.com/cucumber/cucumber-jvm/tree/main/examples/spring-java-junit5) example in Cucumber-JVM for a minimal setup.
 {{% /block %}}
 
 {{% block "ruby,javascript" %}} JUnit 5 and Spring are used with JVM languages. {{% /block %}}

--- a/content/docs/guides/parallel-execution.md
+++ b/content/docs/guides/parallel-execution.md
@@ -23,7 +23,7 @@ For each of these options, this tutorial will look at the project setup, configu
 
 Cucumber Scenarios can be executed in parallel using the **JUnit Platform**.
 
-See the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine) for details.
+See the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine) for details.
 {{% /block %}}
 
 # JUnit 4
@@ -302,7 +302,7 @@ If you have **multiple runners**, set the parallel configuration to `classes` to
 # CLI
 
 {{% block "java,kotlin" %}}
-The `Main class` in the `io.cucumber.core.cli package` is used to execute the feature files. You can run this class directly from the command line; in that case, there is no need to create any runner class. The usage options for this class are mentioned [here](https://github.com/cucumber/cucumber-jvm/blob/v4.0.0/core/src/main/resources/cucumber/api/cli/USAGE.txt). The `--threads` option needs to be set to a value **greater than 1** to run in parallel. When the parallel mode is used, the scenarios and rows in a scenario outline will be run in multiple threads.
+The `Main` class in the `io.cucumber.core.cli` package is used to execute the feature files. You can run this class directly from the command line; in that case, there is no need to create any runner class. The usage options for this class are mentioned [here](https://github.com/cucumber/cucumber-jvm/blob/main/cucumber-core/src/main/resources/io/cucumber/core/options/USAGE.txt). The `--threads` option needs to be set to a value **greater than 1** to run in parallel. When the parallel mode is used, the scenarios and rows in a scenario outline will be run in multiple threads.
 
 Follow the steps below to **execute the command from a terminal**.	
 

--- a/content/docs/installation/java.md
+++ b/content/docs/installation/java.md
@@ -106,7 +106,7 @@ You can now run Cucumber [from the command line](/docs/cucumber/api/#from-the-co
 
 # JUnit 5 integration
 
-It is also possible to use [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine) to run your Cucumber test suite.
+It is also possible to use [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine) to run your Cucumber test suite.
 
 # JUnit 4 integration
 

--- a/content/docs/installation/kotlin.md
+++ b/content/docs/installation/kotlin.md
@@ -8,6 +8,6 @@ weight: 1145
 
 There is no native Kotlin implementation of Cucumber, but you can use [Cucumber-JVM](/docs/installation/java) to write Cucumber tests in Kotlin.
 
-For examples, please see the [kotlin-java8](https://github.com/cucumber/cucumber-jvm/tree/main/kotlin-java8) examples on GitHub.
+For examples, please see the [kotlin-java8](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-kotlin-java8) examples on GitHub.
 
 To get started, have a look at this [blog](https://medium.com/@mlvandijk/kukumber-getting-started-with-cucumber-in-kotlin-e55112e7309b).

--- a/content/docs/installation/scala.md
+++ b/content/docs/installation/scala.md
@@ -33,7 +33,7 @@ libraryDependencies += "io.cucumber" %% "cucumber-scala" % "{{% version "cucumbe
 ```
 # JUnit 5 integration
 
-It is also possible to use [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/junit-platform-engine) to run your Cucumber test suite.
+It is also possible to use [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine) to run your Cucumber test suite.
 
 # JUnit 4 integration
 

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -3,10 +3,10 @@
 # They can be referred to with the custom Hugo shortcode, e.g. {{% version "cucumberjvm" %}}
 #
 
-cucumberjvm: "7.0.0"
+cucumberjvm: "7.5.0"
 cucumberscala: "6.10.4"
 cucumberjs: "7.3.1"
 cucumberruby: "7.1.0"
 rspec: "3.10.0"
-testng: "7.4.0"
-junit: "5.8.1"
+testng: "7.6.1"
+junit: "5.9.0"


### PR DESCRIPTION
With https://github.com/cucumber/cucumber-jvm/pull/2596 the internal structure got
changed somewhat. Updated all the documentation links to match these changes.
