### PR TITLE
Replace detailed instructions with example project

### DIFF
--- a/content/docs/tools/java.md
+++ b/content/docs/tools/java.md
@@ -28,26 +28,7 @@ To run Cucumber with [Maven](https://maven.apache.org/), make sure that:
 - The environment variable `MAVEN_HOME` is correctly configured
 - The IDE is configured with the latest Maven installation
 
-Steps:
-
-1.  Create a new Maven project or fork cucumber-java examples on Github
-2.  Add the following dependency to the `pom.xml`
-
-    ```xml
-    <dependency>
-        <groupId>io.cucumber</groupId>
-      	<artifactId>cucumber-java</artifactId>
-      	<version>{{% version "cucumberjvm" %}}</version>
-    </dependency>
-    ```
-
-3.  Add feature `.feature` files and associated step mapping classes `.java` in `src/test/resources` and `src/test/java` folders respectively.
-4.  Run the following Maven from the directory path where the `pom.xml` file is located:
-
-    ```shell
-    mvn clean install -Dcucumber.glue="package_name_of_step_definitions" \
-       -Dcucumber.plugin="pretty path\to\featurefiles"
-    ```
+Clone the [cucumber-java-skeleton](https://github.com/cucumber/cucumber-java-skeleton) to get started.
 
 ## Gradle
 
@@ -57,58 +38,4 @@ To run Cucumber with [Gradle](https://gradle.org/), make sure that:
 - The environment variable `GRADLE_HOME` is correctly configured
 - The IDE is configured with the latest Gradle installation
 
-Steps:
-
-1.  Create a new Gradle project or look at [gradle-cucumber-runner](https://github.com/tsundberg/gradle-cucumber-runner) example on Github
-2.  If you are going to use Gradle **4.10.3 or older**, add this dependency block to `build.gradle`.
-    ```groovy
-    dependencies {
-        testCompile 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
-    }
-    ```
-
-    For Gradle **5.0 or more recent**, you can add the following dependency block to `build.gradle`.
-    ```groovy
-    dependencies {
-        testImplementation 'io.cucumber:cucumber-java:{{% version "cucumberjvm" %}}'
-    }
-    ```
-
-3. For Gradle **4.10.3 or older**, add the following configuration to `build.gradle`.
-    ```groovy
-    configurations {
-        cucumberRuntime {
-            extendsFrom testRuntime
-        }
-    }
-    ```
-    For Gradle **5.0 or more recent**, the following configuration must be added to `build.gradle`.
-    ```groovy
-    configurations {
-        cucumberRuntime {
-            extendsFrom testImplementation
-        }
-    }
-    ```
-
-4.  Add feature `.feature` files and associated step mapping classes `.java` in `src/test/resources` and `src/test/java` respectively in a `gradle.cucumber` package.
-5.  Add the following Gradle `cucumber` task in `build.gradle`
-
-    ```groovy
-    task cucumber() {
-        dependsOn assemble, testClasses
-        doLast {
-            javaexec {
-                main = "io.cucumber.core.cli.Main"
-                classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
-                args = ['--plugin', 'pretty', '--glue', 'gradle.cucumber', 'src/test/resources']
-            }
-        }
-    }
-    ```
-
-6.  Run the following gradle task from the directory path where `build.gradle` file is located:
-
-    ```shell
-    gradle cucumber
-    ```
+Clone the [cucumber-java-skeleton](https://github.com/cucumber/cucumber-java-skeleton) to get started.


### PR DESCRIPTION
### 🤔 What's changed?

Replaced detailed instructions with example project

### ⚡️ What's your motivation? 
An example project can be kept up to date and ran in CI. These detailed
instructions can not be.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
