### PR TITLE
Update url to the gherkin repository

### DIFF
--- a/content/docs/gherkin/languages.md
+++ b/content/docs/gherkin/languages.md
@@ -5,7 +5,7 @@ subtitle: "Languages in which you can write"
 In order to allow Gherkin to be written in a number of languages, the keywords have been translated into multiple languages. To improve readability and flow, some languages may have more than one translation for any given keyword.
 
 ### Overview
-You can find all translation of Gherkin [on GitHub](https://github.com/cucumber/cucumber/blob/master/gherkin/gherkin-languages.json).
+You can find all translation of Gherkin [on GitHub](https://github.com/cucumber/gherkin).
 This is also the place to add or update translations.
 
 A list of the currently supported languages and their keywords can be found below.


### PR DESCRIPTION
### 🤔 What's changed?

Gherkin has moved from the `common` repo to it's own dedicated repo. Updated
the url accordingly. Dropped the specific path to the translations file,
there are some instructions involved and people currently over look them.

https://github.com/cucumber/gherkin/issues/49

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
