### PR TITLE
Allow raw html in our Markdown templates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,3 +11,6 @@ theme = "cucumber-sb"
 pygmentsUseClassic = true
 pygmentsCodeFences = true
 pygmentsUseClasses = true
+
+[markup.goldmark.renderer]
+  unsafe = true


### PR DESCRIPTION
### ⚡️ What's your motivation? 

While raw-html sounds like raw-sewage, and you should stay away from it, it is in this case a feature we use heavily. The short codes defined in `themes/cucumber-sb/layouts/shortcodes` decorate our plain text with somewhat useful styling and formatting. This is of course done in HTML.

Fixes: #813 Maybe.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
