### PR TITLE
Fix typos & inconsistencies

### DIFF
--- a/content/docs/community/contributing.md
+++ b/content/docs/community/contributing.md
@@ -26,6 +26,7 @@ Before you file an [Issue on Github](https://github.com/cucumber/cucumber/issues
 This way you don't waste time by reporting a bug that has already been fixed.
 
 {{% text "ruby" %}}Try the latest released gem:{{% /text %}}
+
 ``` ruby
 gem update cucumber
 ```

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -84,13 +84,14 @@ by Cucumber (using `DataTable.asList(String.class)`) before invoking the step de
 Short, Long and Double are also supported.{{% /text %}}
 
 {{% block "scala" %}}
+
 **Note:** For now, Cucumber Scala does not support using Scala collection types.
+
 See [Github](https://github.com/cucumber/cucumber-jvm-scala/issues/50)
 
 {{% /block %}}
 
-{{% text "javascript" %}} For an example of data tables in JavaScript, go
-[here](https://github.com/cucumber/cucumber-js/blob/master/src/models/data_table.ts) {{% /text %}}
+{{% text "javascript" %}} For an example of data tables in JavaScript, go [here](https://github.com/cucumber/cucumber-js/blob/master/src/models/data_table.ts) {{% /text %}}
 
 {{% text "java,kotlin" %}}In addition, see
 [cucumber-jvm data-tables](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-java#data-tables){{% /text %}}
@@ -1078,6 +1079,7 @@ It is possible to [configure](/docs/cucumber/configuration) how Cucumber should 
 {{% block "ruby" %}}
 The most common option is to run Cucumber from the command line. By default, Cucumber will treat anything ending in `.rb` under the root library directory as a step definition file.
 Thus, a step contained in `features/models/entities/step_definitions/anything.rb` can be used in a feature file contained in `features/views/entity_new`, provided that:
+
 - Cucumber is invoked on a root directory common to both (`./features`, in this example); OR
 - explicitly required on the command line
 {{% /block %}}
@@ -1085,6 +1087,7 @@ Thus, a step contained in `features/models/entities/step_definitions/anything.rb
 {{% block "javascript" %}}
 The most common option is to run Cucumber from the command line. By default, Cucumber will treat anything ending in`.js` under the root directory as a step definition file.
 Thus, a step contained in `features/models/entities/step-definitions/anything.js` can be used in a feature file, provided that:
+
 - Cucumber is invoked on a root directory common to both (`./features`, in this example); OR
 - explicitly required on the command line
 {{% /block %}}
@@ -1159,7 +1162,7 @@ You can also run features using a [build tool](/docs/tools/general#build-tools) 
 ## JUnit 5 
 
 {{% block "java,kotlin,scala" %}}
-See the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#configuration-options)
+See the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#configuration-options) for more information.
 
 {{% /block %}}
 

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -29,7 +29,6 @@ This conversion can be done either by Cucumber or manually.
 {{% text "java,kotlin" %}}Depending on the table shape as one of the following collections:{{% /text %}}
 
 ```java
-
 List<List<String>> table
 List<Map<String, String>> table
 Map<String, String> table
@@ -48,30 +47,34 @@ Given the following animals:
   | sheep |
 ```
 
-Declare the argument as a {{% text "java,kotlin" %}}`List<String>`{{% /text %}}{{% text "scala" %}}`java.util.List[String]`{{% /text %}}{{% text "ruby,javascript" %}}list of strings{{% /text %}}, but don't define any capture groups in the expression:
+Declare the argument as a {{% text "java,kotlin" %}}`List<String>`{{% /text %}}{{% text "scala" %}}`java.util.List[String]`{{% /text %}}{{% text "ruby,javascript" %}}list of strings{{% /text %}}, but don't define any {{% expression-parameter %}}s in the expression:
 
-{{% text "java" %}}
+{{% block "java" %}}
+Annotated method style:
+
 ```java
 @Given("the following animals:")
 public void the_following_animals(List<String> animals) {
 }
 ```
-{{% /text %}}
+{{% /block %}}
 
-{{% text "kotlin" %}}
+{{% block "kotlin" %}}
+Annotated method style:
+
 ```kotlin
 @Given("the following animals:")
 fun the_following_animals(animals: List<String>) {
 }
 ```
-{{% /text %}}
+{{% /block %}}
 
-{{% text "scala" %}}
+{{% block "scala" %}}
 ```scala
 Given("the following animals:") { animals: java.util.List[String] =>
 }
 ```
-{{% /text %}}
+{{% /block %}}
 
 In this case, the `DataTable` is automatically flattened to a {{% text "java,kotlin" %}}`List<String>`{{% /text %}}{{% text "scala" %}}`java.util.List[String]`{{% /text %}}{{% text "ruby,javascript" %}}array of strings{{% /text %}}
 by Cucumber (using `DataTable.asList(String.class)`) before invoking the step definition.
@@ -107,14 +110,14 @@ Steps are declared in your {{% text "ruby" %}}`features/\*.feature`{{% /text %}}
 ## Matching steps
 
 1. Cucumber matches a step against a step definition's `Regexp`
-2. Cucumber gathers any capture groups or variables
-3. Cucumber passes them to the step definition's {{% text "ruby" %}}`Proc` (or “function”){{% /text %}}{{% text "javascript" %}}function{{% /text %}}{{% text "java,scala" %}}method{{% /text %}} and executes it
+2. Cucumber gathers any {{% expression-parameter %}}s or variables
+3. Cucumber passes them to the step definition's {{% stepdef-body %}} and executes it
 
 Recall that step definitions start with a [preposition](https://www.merriam-webster.com/dictionary/given) or an [adverb](https://www.merriam-webster.com/dictionary/when) (**`Given`**, **`When`**, **`Then`**, **`And`**, **`But`**).
 
 All step definitions are loaded (and defined) before Cucumber starts to execute the plain text in the feature file.
 
-Once execution begins, for each step, Cucumber will look for a registered step definition with a matching `Regexp`. If it finds one, it will execute it, passing all capture groups and variables from the Regexp as arguments to the method or function.
+Once execution begins, for each step, Cucumber will look for a registered step definition with a matching `Regexp`. If it finds one, it will execute it, passing all {{% expression-parameter %}}s and variables from the Regexp as arguments to the {{% stepdef-body %}}.
 
 The specific preposition/adverb used has **no** significance when Cucumber is registering or looking up step definitions.
 
@@ -134,17 +137,17 @@ When Cucumber can't find a matching step definition, the step gets marked as und
 
 #### Pending
 
-When a step definition's method or function invokes the `pending` method, the step is marked as pending (yellow, as with `undefined` ones), indicating that you have work to do.
+When a step definition's {{% stepdef-body %}} invokes the `pending` {{% stepdef-body %}}, the step is marked as pending (yellow, as with `undefined` ones), indicating that you have work to do.
 
 #### Failed Steps
 
-When a step definition's method or function is executed and raises an error, the step is marked as failed (red). What you return from a step definition has no significance whatsoever.
+When a step definition's {{% stepdef-body %}} is executed and raises an error, the step is marked as failed (red). What you return from a step definition has no significance whatsoever.
 
 Returning {{% text "ruby" %}}`nil`{{% /text %}}{{% text "java,kotlin,scala" %}}`null`{{% /text %}}{{% text "javascript" %}}`null`{{% /text %}} or `false` will **not** cause a step definition to fail.
 
 #### Skipped
 
-Steps that follow `undefined`, `pending`, or `failed` steps are never executed,  even if there is a matching step definition. These steps are marked as skipped (cyan).
+Steps that follow `undefined`, `pending`, or `failed` steps are never executed, even if there is a matching step definition. These steps are marked as skipped (cyan).
 
 #### Ambiguous
 
@@ -162,7 +165,7 @@ They are typically used for setup and teardown of the environment before and aft
 Where a hook is defined has no impact on what scenarios or steps it is run for.
 If you want more fine-grained control, you can use [conditional hooks](#conditional-hooks).
 
-{{% text "java" %}}
+{{% text "java,kotlin" %}}
 You can declare hooks in any class.
 {{% /text %}}
 
@@ -280,29 +283,28 @@ Before(10, () -> {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 Before(10) { scenario: Scenario ->
     // Do something before each scenario
 }
 ```
-{{% warn " Using Kotlin named objects or companion objects" %}}
+{{% warn "Using Kotlin named objects or companion objects" %}}
 
-If @BeforeAll, @AfterAll etc are used in Kotlin named objects or companion objects an `io.cucumber.java.InvalidMethodSignatureException`
+If @BeforeAll, @AfterAll etc. are used in Kotlin named objects or companion objects an `io.cucumber.java.InvalidMethodSignatureException`
+will be thrown, as Kotlin will create a class `MyStepDefinitions$Companion` which has non-static methods.
 
-will be thrown. As, Kotlin will create a class `MyStepDefinitions$Companion` which has non-static methods 
+- [read more about it here](https://kotlinlang.org/docs/java-to-kotlin-interop.html#static-methods).
 
-- [ read more about it here](https://kotlinlang.org/docs/java-to-kotlin-interop.html#static-methods).
+The `@JvmStatic` annotation does not prevent this behaviour of Kotlin; it adds the static methods to `MyStepDefinitionsMethod` only. 
 
-The `@JvmStatic` annotation does not prevent this behaviour of Kotlin, it adds the static methods to `MyStepDefinitionsMethod` only. 
+Consequently, Cucumber will detect the static methods in `MyStepDefinitions` class, as well as the non-static methods in `MyStepDefinitions$Companion` class and will complain about the second one.
 
-Consequently, Cucumber will detect the static methods in `MyStepDefinitions` class, as well as the non-static methodss in `MyStepDefinitions$Companion` class and will complain about the second one.
-
-As a soultion to this problem, [ package level functions](https://kotlinlang.org/docs/java-to-kotlin-interop.html#package-level-functions) - this is, withouth companion objects. 
+As a solution to this problem, use [ package level functions](https://kotlinlang.org/docs/java-to-kotlin-interop.html#package-level-functions) - this is, without companion objects. 
 
 {{% /warn %}}
 
 ```kotlin
-
 package io.cucumber.example
 
 import io.cucumber.java.AfterAll
@@ -317,13 +319,12 @@ fun beforeAll() {
 fun afterAll() {
    println("after all")
 }
-
-
 ```
 
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 Before(10) { scenario: Scenario =>
     // Do something before each scenario
@@ -344,7 +345,6 @@ Before(10) { scenario: Scenario =>
 `After` hooks run after the last step of each scenario, even when the step result is `failed`, `undefined`, `pending`, or `skipped`.
 
 {{% block "java" %}}
-
 Annotated method style:
 
 ```java
@@ -401,18 +401,15 @@ end
 
 {{% /block %}}
 
-The `scenario` parameter is optional. If you use it, you can inspect the status
-of the scenario.
+The `scenario` parameter is optional. If you use it, you can inspect the status of the scenario.
 
 For example, you can take a screenshot with
-{{% text "java,javascript,kotlin,scala" %}}[WebDriver](https://www.seleniumhq.org/projects/webdriver/){{% /text %}}{{% text "ruby" %}}[Capybara](https://github.com/teamcapybara/capybara){{% /text %}}
-for failed scenarios and embed them in Cucumber's report.
+{{% text "java,javascript,kotlin,scala" %}}[WebDriver](https://www.seleniumhq.org/projects/webdriver/){{% /text %}}{{% text "ruby" %}}[Capybara](https://github.com/teamcapybara/capybara){{% /text %}} for failed scenarios and embed them in Cucumber's report.
 
 See the [browser automation page](/docs/guides/browser-automation/#screenshot-on-failure) for an example on how to do so.
 
 {{% block "ruby" %}}
 Here is an example in which we exit at the first failure (which could be useful in some cases like [Continuous Integration](/docs/guides/continuous-integration), where fast feedback is important).
-{{% /block %}}
 
 ```ruby
 After do |s|
@@ -420,14 +417,14 @@ After do |s|
   Cucumber.wants_to_quit = true if s.failed?
 end
 ```
+{{% /block %}}
 
 ### Around
 
-{{% text "ruby" %}}
+{{% block "ruby" %}}
 `Around` hooks will run "around" a scenario. This can be used to wrap the execution of a scenario in a block. The `Around` hook receives a `Scenario` object and a block (`Proc`) object. The scenario will be executed when you invoke `block.call`.
 
 The following example will cause scenarios tagged with `@fast` to fail if the execution takes longer than 0.5 seconds:
-{{% /text %}}
 
 ```ruby
 Around('@fast') do |scenario, block|
@@ -436,13 +433,14 @@ Around('@fast') do |scenario, block|
   end
 end
 ```
+{{% /block %}}
 
 {{% block "java,kotlin,scala" %}}Cucumber-JVM does not support `Around` hooks.{{% /block %}}
 {{% block "javascript" %}}Cucumber.js does not support `Around` hooks.{{% /block %}}
 
 ## Step hooks
 {{% text "java,kotlin,scala,javascript" %}}
-Step hooks invoked before and after a step. The hooks have 'invoke around' semantics. Meaning that if a `BeforeStep`
+Step hooks are invoked before and after a step. The hooks have 'invoke around' semantics, meaning that if a `BeforeStep`
 hook is executed the `AfterStep` hooks will also be executed regardless of the result of the step. If a step did not
 pass, the following step and its hooks will be skipped.
 {{% /text %}}
@@ -451,7 +449,9 @@ pass, the following step and its hooks will be skipped.
 
 {{% text "ruby" %}}Cucumber-Ruby does not support `BeforeStep` hooks.{{% /text %}}
 
-{{% text "java" %}}
+{{% block "java" %}}
+Annotated method style:
+
 ```java
 @BeforeStep
 public void doSomethingBeforeStep(Scenario scenario){
@@ -465,9 +465,9 @@ BeforeStep((Scenario scenario) -> {
 
 });
 ```
-{{% /text %}}
+{{% /block %}}
 
-{{% text "kotlin" %}}
+{{% block "kotlin" %}}
 Lambda style:
 
 ```kotlin
@@ -475,17 +475,17 @@ BeforeStep { scenario: Scenario ->
     // doSomething
 }
 ```
-{{% /text %}}
+{{% /block %}}
 
-{{% text "scala" %}}
+{{% block "scala" %}}
 ```scala
 BeforeStep { scenario: Scenario =>
     // doSomething
 }
 ```
-{{% /text %}}
+{{% /block %}}
 
-{{% text "javascript" %}}
+{{% block "javascript" %}}
 ```javascript
 BeforeStep(async function({pickle, pickleStep, gherkinDocument, testCaseStartedId, testStepId}) {
     // doSomething
@@ -495,7 +495,7 @@ BeforeStep({tags: "@foo"}, async function() {
     // apply this hook to only specific scenarios
 })
 ```
-{{% /text %}}
+{{% /block %}}
 
 ### AfterStep
 
@@ -507,6 +507,8 @@ end
 {{% /block %}}
 
 {{% block "java" %}}
+Annotated method style:
+
 ```java
 @AfterStep
 public void doSomethingAfterStep(Scenario scenario){
@@ -548,6 +550,7 @@ AfterStep(async function({pickle, pickleStep, gherkinDocument, result, testCaseS
     // doSomething
 })
 ```
+
 {{% /block %}}
 
 ## Conditional hooks
@@ -639,6 +642,8 @@ BeforeAll(async function () {
 {{% /block %}}
 
 {{%block "java" %}}
+Annotated method style:
+
 ```java
 @BeforeAll
 public static void beforeAll() {
@@ -686,6 +691,8 @@ AfterAll(async function () {
 {{% /block %}}
 
 {{%block "java" %}}
+Annotated method style:
+
 ```java
 @AfterAll
 public static void afterAll() {
@@ -727,7 +734,7 @@ end
 {{% text "ruby" %}}
 This hook will run _only once_: after support has been loaded, and before any features are loaded.
 
-You can use this hook to extend Cucumber. For example you could affect how features are loaded, or register custom formatters programmatically.
+You can use this hook to extend Cucumber. For example, you could affect how features are loaded, or register custom formatters programmatically.
 
 [cucumber-wire](https://github.com/cucumber/cucumber-ruby-wire) is a good example
 of how to use InstallPlugin and what a Cucumber plugin can do.
@@ -812,7 +819,7 @@ Tags that are placed above a `Scenario Outline` will be inherited by `Examples`.
 You can tell Cucumber to only run scenarios with a particular tag:
 
 {{% block "java,kotlin,scala" %}}
-For JUnit 5 see the [cucumber-junit-platform-engine documetation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#tags).
+For JUnit 5 see the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#tags).
 
 For JUnit 4 and TestNG using a JVM system property:
 
@@ -844,7 +851,7 @@ public class RunCucumberTest {}
 {{% block "kotlin" %}}
 ```kotlin
 @CucumberOptions(tags = "@smoke and @fast")
-class RunCucumberTest {}
+class RunCucumberTest
 ```
 {{% /block %}}
 
@@ -885,7 +892,7 @@ public class RunCucumberTest {}
 {{% block "kotlin" %}}
  ```kotlin
 @CucumberOptions(tags = "not @smoke")
-class RunCucumberTest {}
+class RunCucumberTest
 ```
 {{% /block %}}
 
@@ -917,12 +924,12 @@ Another way to run a subset of scenarios is to use the `file.feature:line` patte
 ### Tag expressions
 A tag expression is an *infix boolean expression*. Below are some examples:
 
-Expression           | Description
----------------------|---------------------------------------------------------:
-`@fast`              | Scenarios tagged with `@fast`
-`@wip and not @slow` | Scenarios tagged with `@wip` that aren't also tagged with `@slow`
-`@smoke and @fast`   | Scenarios tagged with both `@smoke` and `@fast`
-`@gui or @database`  | Scenarios tagged with either `@gui` or `@database`
+| Expression           |                                                       Description |
+|----------------------|------------------------------------------------------------------:|
+| `@fast`              |                                     Scenarios tagged with `@fast` |
+| `@wip and not @slow` | Scenarios tagged with `@wip` that aren't also tagged with `@slow` |
+| `@smoke and @fast`   |                   Scenarios tagged with both `@smoke` and `@fast` |
+| `@gui or @database`  |                Scenarios tagged with either `@gui` or `@database` |
 
 For even more advanced tag expressions you can use parenthesis for clarity, or
 to change operator precedence:
@@ -986,7 +993,7 @@ Using the default profile...
 ```
 
 Since version 0.6.0, one can no longer overcome this default setting by adding the `--tags=@wip` to the Cucumber argument
-list on the command line, because now all `--tags` options are ANDed together.  Thus the combination of `--tags @wip` **AND** `--tags ~@wip` fails everywhere.
+list on the command line, because now all `--tags` options are ANDed together.  Thus, the combination of `--tags @wip` **AND** `--tags ~@wip` fails everywhere.
 
 You either must create a special profile in `config/cucumber.yml` to deal with this, or alter the default profile to suit your needs.
 
@@ -1043,7 +1050,7 @@ It is possible to [configure](/docs/cucumber/configuration) how Cucumber should 
 
 {{% block "ruby" %}}
 
-The following command will run the `authenticate_user` feature. Any feature in a sub-directory of `features/` directory must `require` features.
+The following command will run the `authenticate_user` feature. Any feature in a subdirectory of `features/` directory must `require` features.
 
 ```
 cucumber --require features features/authentication/authenticate_user.feature
@@ -1479,10 +1486,9 @@ Usually, the test class will be empty. You can, however, specify several JUnit r
 
 {{% note "Supported JUnit annotations"%}}
 Cucumber supports JUnits `@ClassRule`, `@BeforeClass` and `@AfterClass` annotations.
-These will executed before and after all scenarios. Using these is not recommended, as it limits the portability between different runners;
+These will be executed before and after all scenarios. Using them is not recommended, as it limits the portability between different runners;
 they may not execute correctly when using the commandline, [IntelliJ IDEA](https://www.jetbrains.com/help/idea/cucumber.html) or
-[Cucumber-Eclipse](https://github.com/cucumber/cucumber-eclipse). Instead it is recommended to use Cucumbers `Before`
-and `After` [hooks](#hooks).
+[Cucumber-Eclipse](https://github.com/cucumber/cucumber-eclipse). Instead, it is recommended to use Cucumbers `Before` and `After` [hooks](#hooks).
 {{% /note %}}
 
 The Cucumber runner acts like a suite of a JUnit tests. As such other JUnit features such as Categories, Custom JUnit

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -616,8 +616,11 @@ See more documentation on [tags](#tags).
 ## Global hooks
 
 Global hooks will run once before any scenario is run or after all scenario have
-been run. Put the code at the top-level in your `env.rb` file (or any other file
+been run.
+{{% block "ruby" %}}
+Put the code at the top-level in your `env.rb` file (or any other file
 under `features/support` directory).
+{{% /block %}}
 
 ### BeforeAll
 
@@ -719,26 +722,22 @@ AfterAll {
 
 ## InstallPlugin
 
-{{% text "ruby" %}}
-You may also provide an `InstallPlugin` hook that will be run after Cucumber has been configured. The block you provide will be passed on to Cucumber's configuration (an instance of `Cucumber::Cli::Configuration`), and a wrapper to some cucumber internals as a registry.
-{{% /text %}}
-
 {{% block "ruby" %}}
+You may also provide an `InstallPlugin` hook that will be run after Cucumber has been configured. The block you provide will be passed on to Cucumber's configuration (an instance of `Cucumber::Cli::Configuration`), and a wrapper to some cucumber internals as a registry.
+
 ```ruby
 InstallPlugin do |config, registry|
   puts "Features dwell in #{config.feature_dirs}"
 end
 ```
-{{% /block %}}
 
-{{% text "ruby" %}}
 This hook will run _only once_: after support has been loaded, and before any features are loaded.
 
 You can use this hook to extend Cucumber. For example, you could affect how features are loaded, or register custom formatters programmatically.
 
 [cucumber-wire](https://github.com/cucumber/cucumber-ruby-wire) is a good example
 of how to use InstallPlugin and what a Cucumber plugin can do.
-{{% /text %}}
+{{% /block %}}
 
 {{% text "java,kotlin,scala" %}}Cucumber-JVM does not support the `InstallPlugin` hook.{{% /text %}}
 {{% text "javascript" %}}Cucumber.js does not support the `InstallPlugin` hook.{{% /text %}}
@@ -880,7 +879,11 @@ cucumber --tags "@smoke and @fast"
 
 You can tell Cucumber to ignore scenarios with a particular tag:
 
+{{% block "java,kotlin,scala" %}}
+
 Using JUnit runner class:
+
+{{% /block %}}
 
 {{% block "java" %}}
  ```java

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -1225,11 +1225,11 @@ package.
 
 The `@CucumberOptions` can be used to provide
 [additional configuration](#list-configuration-options) to the runner.
+{{% /block %}}
 
 **Using plugins:**
 
 For example if you want to tell Cucumber to use the two formatter plugins `pretty` and `html`, you can specify it like this:
-{{% /block %}}
 
 {{% block "java" %}}
 
@@ -1333,9 +1333,11 @@ class RunCucumberTest {
 {{% block "java,kotlin,scala" %}}
 The default option for `snippets` is `UNDERSCORE`. This settings can be used to
 specify the way code snippets will be created by Cucumber.
+{{% /block %}}
 
 **Performing a dry-run:**
 
+{{% block "java,kotlin,scala" %}}
 For example if you want to check whether all feature file steps have corresponding step definitions, you can specify it like this:
 {{% /block %}}
 
@@ -1388,9 +1390,11 @@ class RunCucumberTest {
 
 {{% block "java,kotlin,scala" %}}
 The default option for `dryRun` is `false`.
+{{% /block %}}
 
 **Formatting console output:**
 
+{{% block "java,kotlin,scala" %}}
 For example if you want console output from Cucumber in a readable format, you can specify it like this:
 {{% /block %}}
 
@@ -1447,11 +1451,12 @@ class RunCucumberTest {
 {{% block "java,kotlin,scala" %}}
 
 The default option for `monochrome` is `false`.
+{{% /block %}}
 
 **Select scenarios using tags:**
 
+{{% block "java,kotlin,scala" %}}
 For example if you want to tell Cucumber to only run the scenarios specified with specific tags, you can specify it like this:
-
 {{% /block %}}
 
 {{% block "java" %}}
@@ -1501,10 +1506,9 @@ public class RunCucumberTest {
 ```
 {{% /block %}}
 
-{{% block "java,kotlin,scala" %}}
-
 **Specify an object factory:**
 
+{{% block "java,kotlin,scala" %}}
 For example if you are using Cucumber with a DI framework and want to use a custom object factory, you can specify it like this:
 {{% /block %}}
 

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -623,7 +623,7 @@ under `features/support` directory).
 
 `BeforeAll` run before any scenario is run.
 
-{{%block "ruby" %}}
+{{% block "ruby" %}}
 ```ruby
 BeforeAll do
   # Do something before any scenario is executed
@@ -631,7 +631,7 @@ end
 ```
 {{% /block %}}
 
-{{%block "javascript" %}}
+{{% block "javascript" %}}
 ```javascript
 const { BeforeAll } = require('@cucumber/cucumber');
 
@@ -641,7 +641,7 @@ BeforeAll(async function () {
 ```
 {{% /block %}}
 
-{{%block "java" %}}
+{{% block "java" %}}
 Annotated method style:
 
 ```java
@@ -652,7 +652,7 @@ public static void beforeAll() {
 ```
 {{% /block %}}
 
-{{%block "kotlin" %}}
+{{% block "kotlin" %}}
 ```kotlin
 BeforeAll {
     // doSomething
@@ -660,7 +660,7 @@ BeforeAll {
 ```
 {{% /block %}}
 
-{{%block "scala" %}}
+{{% block "scala" %}}
 ```scala
 BeforeAll {
     // doSomething
@@ -672,7 +672,7 @@ BeforeAll {
 
 `AfterAll` run after all scenarios have been executed.
 
-{{%block "ruby" %}}
+{{% block "ruby" %}}
 ```ruby
 AfterAll do
   # Do something after all scenarios have been executed
@@ -680,7 +680,7 @@ end
 ```
 {{% /block %}}
 
-{{%block "javascript" %}}
+{{% block "javascript" %}}
 ```javascript
 const { AfterAll } = require('@cucumber/cucumber');
 
@@ -690,7 +690,7 @@ AfterAll(async function () {
 ```
 {{% /block %}}
 
-{{%block "java" %}}
+{{% block "java" %}}
 Annotated method style:
 
 ```java
@@ -701,7 +701,7 @@ public static void afterAll() {
 ```
 {{% /block %}}
 
-{{%block "kotlin" %}}
+{{% block "kotlin" %}}
 ```kotlin
 AfterAll {
     // doSomething
@@ -709,7 +709,7 @@ AfterAll {
 ```
 {{% /block %}}
 
-{{%block "scala" %}}
+{{% block "scala" %}}
 ```scala
 AfterAll {
     // doSomething

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -967,7 +967,7 @@ Another creative way to use tags is to keep track of where in the development pr
 Feature: Index projects
 ```
 
-{{% text "ruby" %}}
+{{% block "ruby" %}}
 As distributed, Cucumber-Rails builds a Rake task that recognizes the *`@wip`* tag.
 However, any string may be used as a tag and any scenario or entire feature can have multiple tags associated with it.
 
@@ -1019,7 +1019,7 @@ the default profile, then instead of a warning the run will fail.
 Limiting the number of occurrences is commonly used in conjunction with the `@wip` tag to restrict the number of
 unspecified scenarios to manageable levels. Those following [Kanban](https://en.wikipedia.org/wiki/kanban) or
 [Lean Software Development](https://en.wikipedia.org/wiki/Lean_software_development) based methodologies will find this useful.
-{{% /text %}}
+{{% /block %}}
 
 # Running Cucumber
 
@@ -1044,9 +1044,7 @@ It is possible to [configure](/docs/cucumber/configuration) how Cucumber should 
 {{% text "ruby" %}}`features/models/entities/step_definitions/anything.rb`{{% /text %}}
 {{% block "ruby,javascript" %}}can be used in a feature file contained in{{% /text %}}
 {{% text "ruby" %}}`features/views/entity_new`{{% /text %}}
-{{% text "ruby,javascript" %}}
-, provided that:
-
+{{% text "ruby,javascript" %}}, provided that:
 - Cucumber is invoked on a root directory common to both (`./features`, in this example); OR
 - explicitly required on the command line
 {{% /text %}}
@@ -1077,7 +1075,6 @@ The **Command-Line Interface Runner (CLI Runner)** is an executable Java class t
 java io.cucumber.core.cli.Main
 ```
 Note that you will need to add the `cucumber-core` jar and all of its transitive dependencies to your classpath, in addition to the location of your compiled .class files. You can find these jars in [Maven Central](https://mvnrepository.com/repos/central).
-
 
 You will also need to provide the CLI with your step definitions via the `--glue` option followed by its package name, and the filepath of your feature file(s).
 
@@ -1204,6 +1201,7 @@ The `@CucumberOptions` can be used to provide
 **Using plugins:**
 
 For example if you want to tell Cucumber to use the two formatter plugins `pretty` and `html`, you can specify it like this:
+{{% /block %}}
 
 {{% block "java" %}}
 ```java
@@ -1249,8 +1247,10 @@ class RunCucumberTest {
 ```
 {{% /block %}}
 
+{{% block "java,kotlin,scala" %}}
 For example if you want to tell Cucumber to print code snippets for missing
 step definitions use the `summary` plugin, you can specify it like this:
+{{% /block %}}
 
 {{% block "java" %}}
 ```java
@@ -1295,13 +1295,17 @@ class RunCucumberTest {
 }
 ```
 {{% /block %}}
+
+{{% block "java,kotlin,scala" %}}
 The default option for `snippets` is `UNDERSCORE`. This settings can be used to
 specify the way code snippets will be created by Cucumber.
 
 **Performing a dry-run:**
 
 For example if you want to check whether all feature file steps have corresponding step definitions, you can specify it like this:
+{{% /block %}}
 
+{{% block "java" %}}
 ```java
 package com.example;
 
@@ -1314,7 +1318,9 @@ import org.junit.runner.RunWith;
 public class RunCucumberTest {
 }
 ```
+{{% /block %}}
 
+{{% block "kotlin" %}}
 ```kotlin
 package com.example
 
@@ -1326,7 +1332,9 @@ import org.junit.runner.RunWith
 @CucumberOptions(dryRun=true)
 class RunCucumberTest
 ```
+{{% /block %}}
 
+{{% block "scala" %}}
 ```scala
 package com.example;
 
@@ -1339,11 +1347,17 @@ import org.junit.runner.RunWith;
 class RunCucumberTest {
 }
 ```
+{{% /block %}}
+
+{{% block "java,kotlin,scala" %}}
 The default option for `dryRun` is `false`.
 
 **Formatting console output:**
 
 For example if you want console output from Cucumber in a readable format, you can specify it like this:
+{{% /block %}}
+
+{{% block "java" %}}
 
 ```java
 package com.example;
@@ -1358,6 +1372,10 @@ public class RunCucumberTest {
 }
 ```
 
+{{% /block %}}
+
+{{% block "kotlin" %}}
+
 ```kotlin
 package com.example
 
@@ -1369,6 +1387,10 @@ import org.junit.runner.RunWith
 @CucumberOptions(monochrome=true)
 class RunCucumberTest
 ```
+
+{{% /block %}}
+
+{{% block "scala" %}}
 
 ```scala
 package com.example;
@@ -1382,12 +1404,18 @@ import org.junit.runner.RunWith;
 class RunCucumberTest {
 }
 ```
+
+{{% /block %}}
+
+{{% block "java,kotlin,scala" %}}
 
 The default option for `monochrome` is `false`.
 
 **Select scenarios using tags:**
 
 For example if you want to tell Cucumber to only run the scenarios specified with specific tags, you can specify it like this:
+
+{{% /block %}}
 
 {{% block "java" %}}
 ```java
@@ -1433,9 +1461,12 @@ public class RunCucumberTest {
 ```
 {{% /block %}}
 
+{{% block "java,kotlin,scala" %}}
+
 **Specify an object factory:**
 
 For example if you are using Cucumber with a DI framework and want to use a custom object factory, you can specify it like this:
+{{% /block %}}
 
 {{% block "java" %}}
 ```java
@@ -1480,6 +1511,8 @@ public class RunCucumberTest {
 }
 ```
 {{% /block %}}
+
+{{% block "java,kotlin,scala" %}}
 The default option for `objectFactory` is to use the default object factory.
 Additional information about using custom object factories can be found [here](/docs/cucumber/state/#the-cucumber-object-factory).
 

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -70,6 +70,7 @@ fun the_following_animals(animals: List<String>) {
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 Given("the following animals:") { animals: java.util.List[String] =>
 }
@@ -219,6 +220,7 @@ Before { scenario: Scenario ->
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 Before { scenario: Scenario =>
     // doSomething
@@ -227,6 +229,7 @@ Before { scenario: Scenario =>
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 // Import the Before function
 const { Before } = require('@cucumber/cucumber')
@@ -244,6 +247,7 @@ sharing state between hooks and step definitions.
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 Before do
   # Do something before each scenario
@@ -375,6 +379,7 @@ After { scenario: Scenario ->
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 After { scenario: Scenario =>
     // doSomething
@@ -478,6 +483,7 @@ BeforeStep { scenario: Scenario ->
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 BeforeStep { scenario: Scenario =>
     // doSomething
@@ -486,6 +492,7 @@ BeforeStep { scenario: Scenario =>
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 BeforeStep(async function({pickle, pickleStep, gherkinDocument, testCaseStartedId, testStepId}) {
     // doSomething
@@ -500,6 +507,7 @@ BeforeStep({tags: "@foo"}, async function() {
 ### AfterStep
 
 {{% block "ruby" %}}
+
 ```ruby
 AfterStep do |scenario|
 end
@@ -536,6 +544,7 @@ AfterStep { scenario: Scenario ->
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 AfterStep { scenario: Scenario =>
     // doSomething
@@ -545,6 +554,7 @@ AfterStep { scenario: Scenario =>
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 AfterStep(async function({pickle, pickleStep, gherkinDocument, result, testCaseStartedId, testStepId}) {
     // doSomething
@@ -590,6 +600,7 @@ After (arrayOf("@browser and not @headless")) { scenario: Scenario ->
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 After("@browser and not @headless") { scenario: Scenario =>
 
@@ -598,6 +609,7 @@ After("@browser and not @headless") { scenario: Scenario =>
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 Before({tags: '@browser and not @headless'}, async function () {
 })
@@ -605,6 +617,7 @@ Before({tags: '@browser and not @headless'}, async function () {
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 Before('@browser and not @headless') do
 end
@@ -627,6 +640,7 @@ under `features/support` directory).
 `BeforeAll` run before any scenario is run.
 
 {{% block "ruby" %}}
+
 ```ruby
 BeforeAll do
   # Do something before any scenario is executed
@@ -635,6 +649,7 @@ end
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 const { BeforeAll } = require('@cucumber/cucumber');
 
@@ -656,6 +671,7 @@ public static void beforeAll() {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 BeforeAll {
     // doSomething
@@ -664,6 +680,7 @@ BeforeAll {
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 BeforeAll {
     // doSomething
@@ -676,6 +693,7 @@ BeforeAll {
 `AfterAll` run after all scenarios have been executed.
 
 {{% block "ruby" %}}
+
 ```ruby
 AfterAll do
   # Do something after all scenarios have been executed
@@ -684,6 +702,7 @@ end
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 const { AfterAll } = require('@cucumber/cucumber');
 
@@ -705,6 +724,7 @@ public static void afterAll() {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 AfterAll {
     // doSomething
@@ -713,6 +733,7 @@ AfterAll {
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 AfterAll {
     // doSomething
@@ -841,6 +862,7 @@ Or changing your JUnit 4/TestNG  runner class:
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 @CucumberOptions(tags = "@smoke and @fast")
 public class RunCucumberTest {}
@@ -848,6 +870,7 @@ public class RunCucumberTest {}
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 @CucumberOptions(tags = "@smoke and @fast")
 class RunCucumberTest
@@ -855,6 +878,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 @CucumberOptions(tags = "@smoke and @fast")
 class RunCucumberTest {}
@@ -862,6 +886,7 @@ class RunCucumberTest {}
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 # You can omit the quotes if the expression is a single tag
 ./node_modules/.bin/cucumber.js --tags "@smoke and @fast"
@@ -869,6 +894,7 @@ class RunCucumberTest {}
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 # You can omit the quotes if the expression is a single tag
 cucumber --tags "@smoke and @fast"
@@ -907,6 +933,7 @@ class RunCucumberTest {}
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 # You can omit the quotes if the expression is a single tag
 ./node_modules/.bin/cucumber.js --tags "not @smoke"
@@ -914,6 +941,7 @@ class RunCucumberTest {}
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 # You can omit the quotes if the expression is a single tag
 cucumber --tags "not @smoke"
@@ -1204,6 +1232,7 @@ For example if you want to tell Cucumber to use the two formatter plugins `prett
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 
@@ -1219,6 +1248,7 @@ public class RunCucumberTest {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package com.example
 
@@ -1233,6 +1263,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 package com.example;
 
@@ -1253,6 +1284,7 @@ step definitions use the `summary` plugin, you can specify it like this:
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 
@@ -1268,6 +1300,7 @@ public class RunCucumberTest {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package com.example
 
@@ -1282,6 +1315,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 package com.example;
 
@@ -1306,6 +1340,7 @@ For example if you want to check whether all feature file steps have correspondi
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 
@@ -1321,6 +1356,7 @@ public class RunCucumberTest {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package com.example
 
@@ -1335,6 +1371,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 package com.example;
 
@@ -1418,6 +1455,7 @@ For example if you want to tell Cucumber to only run the scenarios specified wit
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 
@@ -1433,6 +1471,7 @@ public class RunCucumberTest {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package com.example
 
@@ -1447,6 +1486,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 package com.example;
 
@@ -1469,6 +1509,7 @@ For example if you are using Cucumber with a DI framework and want to use a cust
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 
@@ -1484,6 +1525,7 @@ public class RunCucumberTest {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package com.example
 
@@ -1498,6 +1540,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 package com.example;
 

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -1225,11 +1225,11 @@ package.
 
 The `@CucumberOptions` can be used to provide
 [additional configuration](#list-configuration-options) to the runner.
-{{% /block %}}
 
 **Using plugins:**
 
 For example if you want to tell Cucumber to use the two formatter plugins `pretty` and `html`, you can specify it like this:
+{{% /block %}}
 
 {{% block "java" %}}
 
@@ -1333,11 +1333,9 @@ class RunCucumberTest {
 {{% block "java,kotlin,scala" %}}
 The default option for `snippets` is `UNDERSCORE`. This settings can be used to
 specify the way code snippets will be created by Cucumber.
-{{% /block %}}
 
 **Performing a dry-run:**
 
-{{% block "java,kotlin,scala" %}}
 For example if you want to check whether all feature file steps have corresponding step definitions, you can specify it like this:
 {{% /block %}}
 
@@ -1390,11 +1388,9 @@ class RunCucumberTest {
 
 {{% block "java,kotlin,scala" %}}
 The default option for `dryRun` is `false`.
-{{% /block %}}
 
 **Formatting console output:**
 
-{{% block "java,kotlin,scala" %}}
 For example if you want console output from Cucumber in a readable format, you can specify it like this:
 {{% /block %}}
 
@@ -1451,12 +1447,11 @@ class RunCucumberTest {
 {{% block "java,kotlin,scala" %}}
 
 The default option for `monochrome` is `false`.
-{{% /block %}}
 
 **Select scenarios using tags:**
 
-{{% block "java,kotlin,scala" %}}
 For example if you want to tell Cucumber to only run the scenarios specified with specific tags, you can specify it like this:
+
 {{% /block %}}
 
 {{% block "java" %}}
@@ -1506,9 +1501,10 @@ public class RunCucumberTest {
 ```
 {{% /block %}}
 
+{{% block "java,kotlin,scala" %}}
+
 **Specify an object factory:**
 
-{{% block "java,kotlin,scala" %}}
 For example if you are using Cucumber with a DI framework and want to use a custom object factory, you can specify it like this:
 {{% /block %}}
 

--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -83,10 +83,11 @@ by Cucumber (using `DataTable.asList(String.class)`) before invoking the step de
 {{% text "java,kotlin" %}}Note: In addition to collections of String, Integer, Float, BigInteger and BigDecimal, Byte,
 Short, Long and Double are also supported.{{% /text %}}
 
-{{% text "scala" %}}
+{{% block "scala" %}}
 **Note:** For now, Cucumber Scala does not support using Scala collection types.
-See [Github](https://github.com/cucumber/cucumber-jvm-scala/issues/50).
-{{% /text %}}
+See [Github](https://github.com/cucumber/cucumber-jvm-scala/issues/50)
+
+{{% /block %}}
 
 {{% text "javascript" %}} For an example of data tables in JavaScript, go
 [here](https://github.com/cucumber/cucumber-js/blob/master/src/models/data_table.ts) {{% /text %}}
@@ -337,10 +338,12 @@ Before(10) { scenario: Scenario =>
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 `Before` hooks run in the **same order** in which they are declared.
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 `Before` hooks run in the **same order** in which they are declared.
 {{% /block %}}
 
@@ -427,6 +430,7 @@ end
 ### Around
 
 {{% block "ruby" %}}
+
 `Around` hooks will run "around" a scenario. This can be used to wrap the execution of a scenario in a block. The `Around` hook receives a `Scenario` object and a block (`Proc`) object. The scenario will be executed when you invoke `block.call`.
 
 The following example will cause scenarios tagged with `@fast` to fail if the execution takes longer than 0.5 seconds:
@@ -839,7 +843,7 @@ Tags that are placed above a `Scenario Outline` will be inherited by `Examples`.
 You can tell Cucumber to only run scenarios with a particular tag:
 
 {{% block "java,kotlin,scala" %}}
-For JUnit 5 see the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#tags).
+For JUnit 5 see the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#tags)
 
 For JUnit 4 and TestNG using a JVM system property:
 
@@ -912,6 +916,7 @@ Using JUnit runner class:
 {{% /block %}}
 
 {{% block "java" %}}
+
  ```java
 @CucumberOptions(tags = "not @smoke")
 public class RunCucumberTest {}
@@ -919,6 +924,7 @@ public class RunCucumberTest {}
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
  ```kotlin
 @CucumberOptions(tags = "not @smoke")
 class RunCucumberTest
@@ -926,6 +932,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "scala" %}}
+
  ```scala
 @CucumberOptions(tags = "not @smoke")
 class RunCucumberTest {}
@@ -1051,34 +1058,38 @@ unspecified scenarios to manageable levels. Those following [Kanban](https://en.
 
 # Running Cucumber
 
-Cucumber is a
-{{% text "java,kotlin,scala" %}}Java library with extensions for different tools and platforms.{{% /text %}}
-{{% text "javascript,ruby" %}}command line tool.{{% /text %}}
-It is launched by running
-{{% text "java,kotlin,scala" %}}JUnit 4, JUnit 5, your build tool, your IDE or the CLI.{{% /text %}}
-{{% text "javascript" %}}`cucumber-js` from the command line, or a build script.{{% /text %}}
-{{% text "ruby" %}}`cucumber` from the command line, or a build script.{{% /text %}}
+{{% block "java,kotlin,scala" %}}
+Cucumber is a Java library with extensions for different tools and platforms.
+It is launched by running JUnit 4, JUnit 5, your build tool, your IDE or the CLI.
+{{% /block %}}
+
+{{% block "javascript" %}}
+Cucumber is a command line tool. It is launched by running `cucumber-js` from the command line, or a build script.
+{{% /block %}}
+
+{{% block "ruby" %}}
+Cucumber is a command line tool. It is launched by running `cucumber` from the command line, or a build script.
+{{% /block %}}
 
 It is possible to [configure](/docs/cucumber/configuration) how Cucumber should run features.
 
 ## From the command line
 
-{{% text "ruby,javascript" %}}The most common option is to run Cucumber from the command line. By default, Cucumber will treat anything ending in{{% /text %}}
-{{% text "javascript" %}}`.js`{{% /text %}}
-{{% text "ruby" %}}`.rb`{{% /text %}} under the root
-{{% text "ruby" %}}library{{% /text %}} directory as a step definition file.
-{{% text "ruby,javascript" %}}Thus, a step contained in {{% /text %}}
-{{% text "javascript" %}}`features/models/entities/step-definitions/anything.js`{{% /text %}}
-{{% text "ruby" %}}`features/models/entities/step_definitions/anything.rb`{{% /text %}}
-{{% block "ruby,javascript" %}}can be used in a feature file contained in{{% /text %}}
-{{% text "ruby" %}}`features/views/entity_new`{{% /text %}}
-{{% text "ruby,javascript" %}}, provided that:
+{{% block "ruby" %}}
+The most common option is to run Cucumber from the command line. By default, Cucumber will treat anything ending in `.rb` under the root library directory as a step definition file.
+Thus, a step contained in `features/models/entities/step_definitions/anything.rb` can be used in a feature file contained in `features/views/entity_new`, provided that:
 - Cucumber is invoked on a root directory common to both (`./features`, in this example); OR
 - explicitly required on the command line
-{{% /text %}}
+{{% /block %}}
+
+{{% block "javascript" %}}
+The most common option is to run Cucumber from the command line. By default, Cucumber will treat anything ending in`.js` under the root directory as a step definition file.
+Thus, a step contained in `features/models/entities/step-definitions/anything.js` can be used in a feature file, provided that:
+- Cucumber is invoked on a root directory common to both (`./features`, in this example); OR
+- explicitly required on the command line
+{{% /block %}}
 
 {{% block "ruby" %}}
-
 The following command will run the `authenticate_user` feature. Any feature in a subdirectory of `features/` directory must `require` features.
 
 ```
@@ -1097,7 +1108,7 @@ cucumber
 {{% /block %}}
 
 {{% block "java,kotlin,scala" %}}
-The **Command-Line Interface Runner (CLI Runner)** is an executable Java class that can be run from the command-line.
+The *Command-Line Interface Runner (CLI Runner)* is an executable Java class that can be run from the command-line.
 
 ```
 java io.cucumber.core.cli.Main
@@ -1149,6 +1160,7 @@ You can also run features using a [build tool](/docs/tools/general#build-tools) 
 
 {{% block "java,kotlin,scala" %}}
 See the [cucumber-junit-platform-engine documentation](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#configuration-options)
+
 {{% /block %}}
 
 {{% block "ruby" %}}
@@ -1176,8 +1188,7 @@ To use JUnit to execute cucumber scenarios add the `cucumber-junit` dependency t
   [...]
 </dependencies>
 ```
-Note that `cucumber-junit` is based on JUnit 4. If you're using JUnit 5, use the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine).
-Or include `junit-vintage-engine` dependency, as well. For more information, please refer to [JUnit 5 documentation](https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4-running).
+Note that `cucumber-junit` is based on JUnit 4. If you're using JUnit 5, use the [cucumber-junit-platform-engine](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine) or include `junit-vintage-engine` dependency, as well. For more information, please refer to [JUnit 5 documentation](https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4-running)
 
 Create an empty class that uses the Cucumber JUnit runner.
 
@@ -1557,7 +1568,7 @@ public class RunCucumberTest {
 
 {{% block "java,kotlin,scala" %}}
 The default option for `objectFactory` is to use the default object factory.
-Additional information about using custom object factories can be found [here](/docs/cucumber/state/#the-cucumber-object-factory).
+Additional information about using custom object factories can be found [here](/docs/cucumber/state/#the-cucumber-object-factory)
 
 There are additional options available in the `@CucumberOptions` annotation.
 
@@ -1567,13 +1578,14 @@ Usually, the test class will be empty. You can, however, specify several JUnit r
 Cucumber supports JUnits `@ClassRule`, `@BeforeClass` and `@AfterClass` annotations.
 These will be executed before and after all scenarios. Using them is not recommended, as it limits the portability between different runners;
 they may not execute correctly when using the commandline, [IntelliJ IDEA](https://www.jetbrains.com/help/idea/cucumber.html) or
-[Cucumber-Eclipse](https://github.com/cucumber/cucumber-eclipse). Instead, it is recommended to use Cucumbers `Before` and `After` [hooks](#hooks).
+[Cucumber-Eclipse](https://github.com/cucumber/cucumber-eclipse) . Instead, it is recommended to use Cucumbers `Before` and `After` [hooks](#hooks).
 {{% /note %}}
 
 The Cucumber runner acts like a suite of a JUnit tests. As such other JUnit features such as Categories, Custom JUnit
 Listeners and Reporters can all be expected to work.
 
-For more information on JUnit, see the [JUnit web site](https://www.junit.org).
+For more information on JUnit, see the [JUnit website](https://www.junit.org)
+
 {{% /block %}}
 
 {{% block "ruby" %}}
@@ -1673,5 +1685,6 @@ You can also define common command-line options in a [`cucumber.yml`](/docs/cucu
 {{% /block %}}
 
 {{% block "javascript" %}}
-For more information on how to configure options, have a look at the [cucumber-js docs on GitHub](https://github.com/cucumber/cucumber-js/blob/master/docs/cli.md).
+For more information on how to configure options, have a look at the [cucumber-js docs on GitHub](https://github.com/cucumber/cucumber-js/blob/master/docs/cli.md)
+
 {{% /block %}}

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -27,6 +27,7 @@ For example, the following class registers a custom "Author" data table type:
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 
@@ -137,7 +138,7 @@ public class StepDefinitions {
 {{% block "kotlin" %}}
 
 ```kotlin
-package com.example;
+package com.example
 
 import io.cucumber.java.ParameterType
 import io.cucumber.java.en.Given
@@ -220,7 +221,7 @@ public class StepsDefinitions {
 package com.example
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.cucumber.java.DocStringType
 import io.cucumber.java.en.Given
@@ -320,8 +321,8 @@ public class LambdaStepDefinitions implements En {
 ```kotlin
 package com.example
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 
 import io.cucumber.java8.En
 
@@ -387,6 +388,7 @@ public class StepDefinitions {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package com.example
 
@@ -412,6 +414,7 @@ class StepDefinitions {
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 package com.example
 
@@ -445,6 +448,7 @@ For lambda defined step definitions, there are `DefaultParameterTransformer`,
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 
@@ -473,6 +477,7 @@ public class LambdaStepDefinitions implements En {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 import com.fasterxml.jackson.databind.ObjectMapper
 

--- a/content/docs/cucumber/configuration.md
+++ b/content/docs/cucumber/configuration.md
@@ -528,6 +528,7 @@ end
 
 {{% block "java,kotlin,scala,ruby" %}}
 If you are using a type that has not yet been defined, you will get an error similar to:
+
 ```shell
 The parameter type "person" is not defined.
 ```
@@ -556,7 +557,7 @@ This is just a convention though; Cucumber will pick them up from any file{{% te
 # Profiles
 
 {{% block "java,kotlin,scala" %}}
-Cucumber profiles are not available on Cucumber-JVM.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
+Cucumber profiles are not available on Cucumber-JVM.  However, it is possible to set configuration options using [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html)
 
 For instance, we can configure separate profiles for scenarios which are to be run in separate environments like so:
 

--- a/content/docs/cucumber/reporting.md
+++ b/content/docs/cucumber/reporting.md
@@ -34,7 +34,7 @@ Publishing to the Cucumber Reports service is currently supported in:
 If you don't want to publish your reports to the [Cucumber Reports](https://reports.cucumber.io/) service, you can
 generate local reports using one of the following built-in reporter plugins (also known as "formatters"):
 
-{{% text "java,kotlin" %}}
+{{% block "java,kotlin" %}}
 * `message`
 * `progress`
 * `pretty`
@@ -43,9 +43,9 @@ generate local reports using one of the following built-in reporter plugins (als
 * `rerun`
 * `junit`
 * `testng`
-{{% /text %}}
+{{% /block %}}
 
-{{% text "javascript" %}}
+{{% block "javascript" %}}
 * `message`
 * `html`
 * `json`
@@ -55,9 +55,9 @@ generate local reports using one of the following built-in reporter plugins (als
 * `usage`
 
 There is also a "pretty" formatter available as an optional module [@cucumber/pretty-formatter](https://www.npmjs.com/package/@cucumber/pretty-formatter).
-{{% /text %}}
+{{% /block %}}
 
-{{% text "ruby" %}}
+{{% block "ruby" %}}
 * `message`
 * `progress`
 * `pretty`
@@ -65,34 +65,34 @@ There is also a "pretty" formatter available as an optional module [@cucumber/pr
 * `json`
 * `rerun`
 * `junit`
-{{% /text %}}
+{{% /block %}}
 
 # Custom formatters
 
 Cucumber implementations are extensible so that you can write and use your own formatter, or use a third-party one published by someone else. This involves creating a class that implements/extends the standard formatter interface.
 
-{{% text "javascript" %}}
+{{% block "javascript" %}}
 Detailed documentation around how to use and write custom formatters in cucumber-js is available here:
 
 * https://github.com/cucumber/cucumber-js/blob/master/docs/cli.md#formats
 * https://github.com/cucumber/cucumber-js/blob/master/docs/custom_formatters.md
-{{% /text %}}
+{{% /block %}}
 
-{{% text "ruby" %}}
+{{% block "ruby" %}}
 Once you add your formatter class in the `features/support` directory, you can reference it with the `--format` flag:
 
 ```
 cucumber --format MyModule::CustomFormatter
 ```
-{{% /text %}}
+{{% /block %}}
 
-{{% text "java,kotlin" %}}
+{{% block "java,kotlin" %}}
 Once you add your formatter class, you can reference it with the `--format` flag:
 
 ```
 cucumber --format CustomFormatter
 ```
-{{% /text %}}
+{{% /block %}}
 
 ## Formatter API
 
@@ -117,6 +117,6 @@ There are also many third-party plugins:
 * [cucumber_characteristics](https://github.com/singram/cucumber_characteristics) - Generates HTML/JSON reports on overall test timings, as well as timings and usage of Steps, Features, and Examples. Also lists unused and ambiguous (Cucumber 1.x) Steps. Compatible with Cucumber 1.x and 2.1+ and Ruby 1.9+.
 * [allure-cucumber](https://github.com/allure-framework/allure-cucumber) - [Allure](https://github.com/allure-framework) adaptor for Cucumber. This formatter generates the XML files for Allure reporting framework.
 * [Cluecumber](https://github.com/trivago/cluecumber-report-plugin) - Maven plugin for clear and concise Cucumber reporting.
-* [Cucelastic] (https://github.com/AshisRaj/cucelastic-maven-plugin) - Maven plugin to push test report data into Elastic Search to enable users to plugin UI agnostic tools like Kibana to visualize a dynamic and easy sharable report/dashboad with the possibility to filter and analyze the data, extend and share it across teams.
+* [Cucelastic] (https://github.com/AshisRaj/cucelastic-maven-plugin) - Maven plugin to push test report data into Elastic Search to enable users to plugin UI agnostic tools like Kibana to visualize a dynamic and easy sharable report/dashboard with the possibility to filter and analyze the data, extend and share it across teams.
 * [cucumber-reporting-plugin](https://gitlab.com/jamietanna/cucumber-reporting-plugin) - A Cucumber plugin which produces pretty HTML reports using [cucumber-reporting](https://github.com/damianszczepanik/cucumber-reporting)
 * [Serenity/JS](https://serenity-js.org/handbook/integration/serenityjs-and-cucumber.html) - An acceptance testing and reporting framework with in-depth HTML reports, Screenplay Pattern APIs, and support for every single version of Cucumber.js

--- a/content/docs/cucumber/reporting.md
+++ b/content/docs/cucumber/reporting.md
@@ -35,6 +35,7 @@ If you don't want to publish your reports to the [Cucumber Reports](https://repo
 generate local reports using one of the following built-in reporter plugins (also known as "formatters"):
 
 {{% block "java,kotlin" %}}
+
 * `message`
 * `progress`
 * `pretty`
@@ -46,6 +47,7 @@ generate local reports using one of the following built-in reporter plugins (als
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 * `message`
 * `html`
 * `json`
@@ -58,6 +60,7 @@ There is also a "pretty" formatter available as an optional module [@cucumber/pr
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 * `message`
 * `progress`
 * `pretty`
@@ -117,6 +120,6 @@ There are also many third-party plugins:
 * [cucumber_characteristics](https://github.com/singram/cucumber_characteristics) - Generates HTML/JSON reports on overall test timings, as well as timings and usage of Steps, Features, and Examples. Also lists unused and ambiguous (Cucumber 1.x) Steps. Compatible with Cucumber 1.x and 2.1+ and Ruby 1.9+.
 * [allure-cucumber](https://github.com/allure-framework/allure-cucumber) - [Allure](https://github.com/allure-framework) adaptor for Cucumber. This formatter generates the XML files for Allure reporting framework.
 * [Cluecumber](https://github.com/trivago/cluecumber-report-plugin) - Maven plugin for clear and concise Cucumber reporting.
-* [Cucelastic] (https://github.com/AshisRaj/cucelastic-maven-plugin) - Maven plugin to push test report data into Elastic Search to enable users to plugin UI agnostic tools like Kibana to visualize a dynamic and easy sharable report/dashboard with the possibility to filter and analyze the data, extend and share it across teams.
+* [Cucelastic](https://github.com/AshisRaj/cucelastic-maven-plugin) - Maven plugin to push test report data into Elastic Search to enable users to plugin UI agnostic tools like Kibana to visualize a dynamic and easy sharable report/dashboard with the possibility to filter and analyze the data, extend and share it across teams.
 * [cucumber-reporting-plugin](https://gitlab.com/jamietanna/cucumber-reporting-plugin) - A Cucumber plugin which produces pretty HTML reports using [cucumber-reporting](https://github.com/damianszczepanik/cucumber-reporting)
 * [Serenity/JS](https://serenity-js.org/handbook/integration/serenityjs-and-cucumber.html) - An acceptance testing and reporting framework with in-depth HTML reports, Screenplay Pattern APIs, and support for every single version of Cucumber.js

--- a/content/docs/cucumber/step-definitions.md
+++ b/content/docs/cucumber/step-definitions.md
@@ -139,7 +139,7 @@ Given('I have {int} cukes in my belly', function (cukes) {
 
 A step definition's *expression* can either be a [Regular Expression](https://en.wikipedia.org/wiki/Regular_expression)
 or a [Cucumber Expression](/docs/cucumber/cucumber-expressions). The examples in this section use Cucumber Expressions. 
-If you prefer to use Regular Expressions, each *capture group* from the match will be passed as arguments to the step
+If you prefer to use Regular Expressions, each *{{% expression-parameter %}}* from the match will be passed as arguments to the step
 definition's {{% stepdef-body %}}.
 
 {{% block "java" %}}
@@ -185,7 +185,7 @@ Given(/I have {int} cukes in my belly/, function (cukes) {
 ```
 {{% /block %}}
 
-If the capture group expression is identical to one of the registered
+If the {{% expression-parameter %}} expression is identical to one of the registered
 [parameter types](/docs/cucumber/cucumber-expressions#parameter-types)'s `regexp`,
 the captured string will be transformed before it is passed to the
 step definition's {{% stepdef-body %}}. In the example above, the `cukes`

--- a/content/docs/cucumber/step-definitions.md
+++ b/content/docs/cucumber/step-definitions.md
@@ -30,6 +30,7 @@ Scenario: Some cukes
 The `I have 48 cukes in my belly` part of the step (the text following the `Given` keyword) will match the following step definition:
 
 {{% block "java" %}}
+
 ```java
 package com.example;
 import io.cucumber.java.en.Given;
@@ -115,6 +116,7 @@ class StepDefinitions extends ScalaDsl with EN {
 
 
 {{% block "ruby" %}}
+
 ```ruby
 Given('I have {int} cukes in my belly') do |cukes|
   puts "Cukes: #{cukes}"
@@ -123,6 +125,7 @@ end
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 const { Given } = require('cucumber')
 
@@ -140,6 +143,7 @@ If you prefer to use Regular Expressions, each *capture group* from the match wi
 definition's {{% stepdef-body %}}.
 
 {{% block "java" %}}
+
 ```java
 @Given("I have {int} cukes in my belly")
 public void i_have_n_cukes_in_my_belly(int cukes) {
@@ -148,6 +152,7 @@ public void i_have_n_cukes_in_my_belly(int cukes) {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 Given("I have {int} cukes in my belly") { cukes: Int ->
         println("Cukes: $cukes")
@@ -156,6 +161,7 @@ Given("I have {int} cukes in my belly") { cukes: Int ->
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 Given("I have {int} cukes in my belly") { cukes: Int =>
     println(s"Cukes: $cukes")
@@ -164,6 +170,7 @@ Given("I have {int} cukes in my belly") { cukes: Int =>
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 Given(/I have {int} cukes in my belly/) do |cukes|
 end
@@ -171,6 +178,7 @@ end
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 Given(/I have {int} cukes in my belly/, function (cukes) {
 });
@@ -224,6 +232,7 @@ If you don't have a matching step definition, Cucumber will suggest the followin
 snippet:
 
 {{% block "java" %}}
+
 ```java
 @Given("I have {int} red balls")
 public void i_have_red_balls(int int1) {
@@ -232,6 +241,7 @@ public void i_have_red_balls(int int1) {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 @Given("I have {int} red balls") { balls: Int ->
 }
@@ -239,6 +249,7 @@ public void i_have_red_balls(int int1) {
 {{% /block %}}
 
 {{% block "scala" %}}
+
 ```scala
 Given("I have {int} red balls") { balls: Int =>
 }
@@ -246,6 +257,7 @@ Given("I have {int} red balls") { balls: Int =>
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 Given('I have {int} red balls') do |int1|
 end
@@ -253,6 +265,7 @@ end
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 Given("I have {int} red balls", function (int1) {
 });
@@ -264,6 +277,7 @@ if they match parts of your undefined step. If a [color](/docs/cucumber/cucumber
 parameter type exists, Cucumber would use that in the suggested expression:
 
 {{% block "java" %}}
+
 ```java
 @Given("I have {int} {color} balls")
 public void i_have_color_balls(int int1, Color color) {
@@ -272,6 +286,7 @@ public void i_have_color_balls(int int1, Color color) {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 @Given("I have {int} {color} balls") { balls: Int, color: Color ->
 }
@@ -279,6 +294,7 @@ public void i_have_color_balls(int int1, Color color) {
 {{% /block %}}}
 
 {{% block "scala" %}}
+
 ```scala
 Given("I have {int} {color} balls") { (balls: Int, color: Color) =>
 }
@@ -286,6 +302,7 @@ Given("I have {int} {color} balls") { (balls: Int, color: Color) =>
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 Given('I have {int} {color} balls') do |int1, color|
 end
@@ -293,6 +310,7 @@ end
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 Given("I have {int} {color} balls", function (int1, color) {
 });

--- a/content/docs/cucumber/step-definitions.md
+++ b/content/docs/cucumber/step-definitions.md
@@ -11,13 +11,7 @@ polyglot:
 weight: 1
 ---
 
-A Step Definition is a
-{{% text "java" %}}Java method{{% /text %}}
-{{% text "kotlin" %}}Kotlin function{{% /text %}}
-{{% text "scala" %}}Scala function{{% /text %}}
-{{% text "javascript" %}}JavaScript function{{% /text %}}
-{{% text "ruby" %}}Ruby block{{% /text %}}
-with an [expression](#expressions) that links it to one or more [Gherkin steps](/docs/gherkin/reference#steps).
+A Step Definition is a {{% stepdef-body %}} with an [expression](#expressions) that links it to one or more [Gherkin steps](/docs/gherkin/reference#steps).
 When Cucumber executes a [Gherkin step](/docs/gherkin/reference#steps) in a scenario, it will look for a matching *step definition* to execute.
 
 To illustrate how this works, look at the following Gherkin Scenario:
@@ -139,7 +133,7 @@ Given('I have {int} cukes in my belly', function (cukes) {
 
 A step definition's *expression* can either be a [Regular Expression](https://en.wikipedia.org/wiki/Regular_expression)
 or a [Cucumber Expression](/docs/cucumber/cucumber-expressions). The examples in this section use Cucumber Expressions. 
-If you prefer to use Regular Expressions, each *{{% expression-parameter %}}* from the match will be passed as arguments to the step
+If you prefer to use Regular Expressions, each {{% expression-parameter %}} from the match will be passed as arguments to the step
 definition's {{% stepdef-body %}}.
 
 {{% block "java" %}}

--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -24,6 +24,7 @@ Friday yet.
 Please be aware that this tutorial assumes that you have a:
 
 {{% block "java" %}}
+
 * Basic understanding of the Java programming language
 {{% /block %}}
 {{% block "kotlin" %}}

--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -1399,8 +1399,9 @@ function isItFriday(today) {
 ```
 {{% /block %}}
 
-{{% block "ruby" 
-ruby
+{{% block "ruby" %}}
+
+```ruby
 def is_it_friday(day)
   if day == 'Friday'
     'TGIF'

--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -408,12 +408,14 @@ You now have a small project with Cucumber installed.
 To make sure everything works together correctly, let's run Cucumber.
 
 {{% block "java,kotlin" %}}
+
 ```shell
 mvn test
 ```
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 # Run via NPM
 npm test
@@ -424,6 +426,7 @@ npx cucumber-js
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 cucumber
 ```
@@ -432,6 +435,7 @@ cucumber
 You should see something like the following:
 
 {{% block "java,kotlin" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -451,6 +455,7 @@ Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 0 Scenarios
 0 steps
@@ -459,6 +464,7 @@ Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 0 scenarios
 0 steps
@@ -524,6 +530,7 @@ The last three lines starting with `Given`, `When` and `Then` are the
 Now that we have a scenario, we can ask Cucumber to execute it.
 
 {{% block "java,kotlin" %}}
+
 ```shell
 mvn test
 ```
@@ -531,6 +538,7 @@ mvn test
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 npm test
 ```
@@ -548,6 +556,7 @@ steps.  It's also suggesting some snippets of code that we can use to
 *define* these steps:
 
 {{% block "java,kotlin" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -599,6 +608,7 @@ public void i_should_be_told(String string) {
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 UUU
 
@@ -637,6 +647,7 @@ Warnings:
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 Feature: Is it Friday yet?
   Everybody wants to know when it's Friday
@@ -718,6 +729,7 @@ class StepDefs {
 Run Cucumber again. This time the output is a little different:
 
 {{% block "java" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -749,6 +761,7 @@ io.cucumber.java.PendingException: TODO: implement me
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -779,6 +792,7 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.351 sec
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 P--
 
@@ -797,6 +811,7 @@ Warnings:
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 Feature: Is it Friday yet?
   Everybody wants to know when it's Friday
@@ -836,6 +851,7 @@ which we believe is a great way to make your production code and tests more unde
 Change your step definition code to this:
 
 {{% block "java" %}}
+
 ```java
 package hellocucumber;
 
@@ -873,6 +889,7 @@ public class Stepdefs {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package hellocucumber
 
@@ -908,6 +925,7 @@ class StepDefs {
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 const assert = require('assert');
 const { Given, When, Then } = require('@cucumber/cucumber');
@@ -931,6 +949,7 @@ Then('I should be told {string}', function (expectedAnswer) {
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 module FridayStepHelper
   def is_it_friday(day)
@@ -956,6 +975,7 @@ end
 Run Cucumber again:
 
 {{% block "java" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -987,6 +1007,7 @@ hellocucumber/is_it_friday_yet.feature:4 # Sunday isn't Friday
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -1008,6 +1029,7 @@ Feature: Is it Friday yet?
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 ..F
 
@@ -1026,6 +1048,7 @@ Failures:
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 Feature: Is it Friday yet?
   Everybody wants to know when it's Friday
@@ -1059,6 +1082,7 @@ That's progress! The first two steps are passing, but the last one is failing.
 Let's do the minimum we need to make the scenario pass. In this case, that means making our {{% stepdef-body %}} return `Nope`:
 
 {{% block "java" %}}
+
 ```java
 static String isItFriday(String today) {
     return "Nope";
@@ -1067,12 +1091,14 @@ static String isItFriday(String today) {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 fun isItFriday(today: String) = "Nope"
 ```
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 function isItFriday(today) {
   return 'Nope';
@@ -1080,6 +1106,7 @@ function isItFriday(today) {
 ```
 {{% /block %}}
 {{% block "ruby" %}}
+
 ```ruby
 def is_it_friday(day)
   'Nope'
@@ -1090,6 +1117,7 @@ end
 Run Cucumber again:
 
 {{% block "java,kotlin" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -1110,6 +1138,7 @@ Feature: Is it Friday yet?
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 ...
 
@@ -1120,6 +1149,7 @@ Feature: Is it Friday yet?
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 Feature: Is it Friday yet?
   Everybody wants to know when it's Friday
@@ -1159,6 +1189,7 @@ Feature: Is it Friday yet?
 We'll need to add a step definition to set `today` to "Friday":
 
 {{% block "java" %}}
+
 ```java
 @Given("today is Friday")
 public void today_is_Friday() {
@@ -1168,6 +1199,7 @@ public void today_is_Friday() {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 @Given("today is Friday")
 fun today_is_Friday() {
@@ -1177,6 +1209,7 @@ fun today_is_Friday() {
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 Given('today is Friday', function () {
   this.today = 'Friday';
@@ -1185,6 +1218,7 @@ Given('today is Friday', function () {
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 Given("today is Friday") do
   @today = 'Friday'
@@ -1196,6 +1230,7 @@ end
 When we run this test, it will fail.
 
 {{% block "java" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -1236,6 +1271,7 @@ org.junit.ComparisonFailure: expected:<[TGIF]> but was:<[Nope]>
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 .....F
 
@@ -1259,6 +1295,7 @@ Failures:
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 Feature: Is it Friday yet?
   Everybody wants to know when it's Friday
@@ -1290,6 +1327,7 @@ cucumber features/is_it_friday_yet.feature:9 # Scenario: Friday is Friday
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```shell
 Running hellocucumber.RunCucumberTest
 Feature: Is it Friday yet?
@@ -1333,6 +1371,7 @@ That is because we haven't implemented the logic yet! Let's do that next.
 We should update our statement to actually evaluate whether or not `today` is equal to `"Friday"`.
 
 {{% block "java" %}}
+
 ```java
 static String isItFriday(String today) {
     return "Friday".equals(today) ? "TGIF" : "Nope";
@@ -1341,12 +1380,14 @@ static String isItFriday(String today) {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 fun isItFriday(today: String) = if (today == "Friday") "TGIF" else "Nope"
 ```
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 function isItFriday(today) {
   if (today === "Friday") {
@@ -1358,8 +1399,8 @@ function isItFriday(today) {
 ```
 {{% /block %}}
 
-{{% block "ruby" %}}
-```ruby
+{{% block "ruby" 
+ruby
 def is_it_friday(day)
   if day == 'Friday'
     'TGIF'
@@ -1373,6 +1414,7 @@ end
 Run Cucumber again:
 
 {{% block "java,kotlin" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -1398,6 +1440,7 @@ Feature: Is it Friday yet?
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 ......
 2 scenarios (2 passed)
@@ -1407,6 +1450,7 @@ Feature: Is it Friday yet?
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 Feature: Is it Friday yet?
   Everybody wants to know when it's Friday
@@ -1451,6 +1495,7 @@ We need to replace the step definitions for `today is Sunday` and `today is Frid
 Update the {{% text "java" %}}`StepDefinitions.java`{{% /text %}}{{% text "javascript" %}}`stepdefs.js`{{% /text %}}{{% text "ruby" %}}`stepdefs.rb`{{% /text %}} file as follows:
 
 {{% block "java" %}}
+
 ```java
 package hellocucumber;
 
@@ -1488,13 +1533,14 @@ public class Stepdefs {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 package hellocucumber
 
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.When
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals
 
 fun isItFriday(today: String) = if (today == "Friday") "TGIF" else "Nope"
 
@@ -1522,6 +1568,7 @@ class StepDefs {
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```javascript
 const assert = require('assert');
 const { Given, When, Then } = require('@cucumber/cucumber');
@@ -1550,6 +1597,7 @@ Then('I should be told {string}', function (expectedAnswer) {
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```ruby
 module FridayStepHelper
   def is_it_friday(day)
@@ -1580,6 +1628,7 @@ end
 Run Cucumber again:
 
 {{% block "java,kotlin" %}}
+
 ```shell
 -------------------------------------------------------
  T E S T S
@@ -1617,6 +1666,7 @@ Feature: Is it Friday yet?
 {{% /block %}}
 
 {{% block "javascript" %}}
+
 ```shell
 .........
 
@@ -1627,6 +1677,7 @@ Feature: Is it Friday yet?
 {{% /block %}}
 
 {{% block "ruby" %}}
+
 ```shell
 Feature: Is it Friday yet?
   Everybody wants to know when it's Friday

--- a/content/docs/guides/browser-automation.md
+++ b/content/docs/guides/browser-automation.md
@@ -79,7 +79,7 @@ public class ExampleSteps {
 ```
 
 ```kotlin
-package com.example;
+package com.example
 
 import io.cucumber.java8.Scenario
 import io.cucumber.java8.En
@@ -98,7 +98,7 @@ class ExampleSteps: En {
         }
 
         When("I search for {string}") { query: String ->
-            val element: WebElement = driver.findElement(By.name("q"));
+            val element: WebElement = driver.findElement(By.name("q"))
             // Enter something to search for
             element.sendKeys(query)
             // Now submit the form. WebDriver will find the form for us from the element
@@ -395,12 +395,14 @@ public class WebDriverFactory {
 
 Then, define the `browser` property when you run Cucumber:
 {{% text "ruby" %}}
+
 ```
 browser=chrome cucumber
 ```
 {{% /text %}}
 
 {{% text "java,kotlin" %}}
+
 ```
 mvn test -Dbrowser=chrome
 ```
@@ -413,6 +415,7 @@ mvn test -Ddriver=chrome
 {{% /text %}}
 
 {{% text "javascript" %}}
+
 ```
 // TODO: How to pass arguments in JavaScript
 ```

--- a/content/docs/guides/parallel-execution.md
+++ b/content/docs/guides/parallel-execution.md
@@ -159,6 +159,7 @@ Thread ID - 14 - Scenario 2 from scenarios feature file.
 {{% block "kotlin" %}}
 For Failsafe to find your step definitions, make sure they are in src/test/**java**.
 {{% /block %}}
+
 ```shell
 <plugin>
 	<groupId>org.apache.maven.plugins</groupId>
@@ -363,12 +364,14 @@ For a **visual representation** of threads, add the **timeline report** using th
 {{% /block %}}
 
 {{% block "java" %}}
+
 ```java
 @CucumberOptions(plugin= {"timeline:<report folder>"})
 ```
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 ```kotlin
 @CucumberOptions(plugin = ["timeline:<report folder>"])
 ```

--- a/content/docs/guides/parallel-execution.md
+++ b/content/docs/guides/parallel-execution.md
@@ -8,7 +8,9 @@ polyglot:
 weight: 1800
 ---
 {{% block "java,kotlin" %}}
-Cucumber-JVM allows parallel execution across multiple threads since [version 4.0.0.](https://cucumber.io/blog/announcing-cucumber-jvm-4-0-0/) There are several options to incorporate this built-in feature in a Cucumber project. You can do so using:
+Cucumber-JVM allows parallel execution across multiple threads since [version 4.0.0.](https://cucumber.io/blog/announcing-cucumber-jvm-4-0-0/) 
+
+There are several options to incorporate this built-in feature in a Cucumber project. You can do so using:
 
 - [JUnit 5](/docs/guides/parallel-execution/#junit-5)
 - [JUnit 4](/docs/guides/parallel-execution/#junit-4)

--- a/content/docs/guides/parallel-execution.md
+++ b/content/docs/guides/parallel-execution.md
@@ -61,6 +61,7 @@ Feature: Scenario Outlines feature file
 {{% /block %}}
 
 {{% block "java" %}}
+
 - Add the **step definition class** to the `parallel` package (same name as folder above for automatic pickup by runner) in `src/test/java` folder.
 
 ```java
@@ -81,6 +82,7 @@ public class StepDefs {
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 - Add the **step definition class** to the `parallel` package (same name as folder above for automatic pickup by runner) in `src/test/kotlin` folder.
 
 ```kotlin
@@ -99,10 +101,12 @@ class StepDefs : En {
 {{% /block %}}
 
 {{% block "java" %}}
+
 - Add a cucumber **runner** using the `RunWith` annotation in the `parallel` package (same name as step definition package) in the `src/test/java` folder.
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 - Add a cucumber **runner** using the `RunWith` annotation in the `parallel` package (same name as step definition package) in the `src/test/kotlin` folder.
 {{% /block %}}
 
@@ -134,6 +138,7 @@ class RunCucumberTest
 {{% /block %}}
 
 {{% block "java,kotlin" %}}
+
 - Add the **Surefire plugin configuration** to the `build` section to the `POM`.
 
 ```shell
@@ -220,6 +225,7 @@ Cucumber can be executed in parallel using **TestNG and Maven test execution plu
 {{% /block %}}
 
 {{% block "java" %}}
+
 - Add a cucumber **runner** by **extending** the `AbstractTestNGCucumberTests` class and **overriding the scenarios method** in the `parallel` package (same name as step definition package) in `src/test/java` folder. Set the **parallel option value to true** for the DataProvider annotation.
 
 ```java
@@ -240,6 +246,7 @@ public class RunCucumberTest extends AbstractTestNGCucumberTests{
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 - Add a cucumber **runner** by **extending** the `AbstractTestNGCucumberTests` class and **overriding the scenarios method** in the `parallel` package (same name as step definition package) in `src/test/kotlin` folder. Set the **parallel option value to true** for the DataProvider annotation.
 
 ```kotlin
@@ -259,6 +266,7 @@ class RunCucumberTest : AbstractTestNGCucumberTests() {
 {{% /block %}}
 
 {{% block "java,kotlin" %}}
+
 - Add the Maven **Surefire plugin configuration** to the `build` section of the `POM`.
 
 ```shell
@@ -315,6 +323,7 @@ Follow the steps below to **execute the command from a terminal**.
 {{% /block %}}
 
 {{% block "java" %}}
+
 - Compile the step definition class. Add the **path to the folder containing cucumber jars to the classpath** using the **-cp** option.
 
 ```shell
@@ -323,6 +332,7 @@ javac -cp .;<path to cucumber jar folder>/* ./parallel/StepDefs.java
 {{% /block %}}
 
 {{% block "kotlin" %}}
+
 - Compile the step definition class. Add **path to each of the downloaded cucumber jars to the classpath** using the **-cp** option.
 
 ```shell
@@ -331,6 +341,7 @@ kotlinc -cp .;<path to each cucumber jar> -jvm-target 1.8 ./parallel/StepDefs.kt
 {{% /block %}}
 
 {{% block "java,kotlin" %}}
+
 - Execute using the below command.
 {{% /block %}}
 
@@ -349,6 +360,7 @@ java -cp .;<path to cucumber jar folder>/*;<path to kotlin lib folder>/* io.cucu
 {{% /block %}}
 
 {{% block "java,kotlin" %}}
+
 - You should get a console output similar to below.
 
 ```shell


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request 
if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here 
to help and will coach you through to getting your pull 
request ready to merge.

The prompts below are for guidance to help you describe 
your change in a way that is most likely to make sense 
to other people when they are reviewing it. Still, it's 
just a guide, so feel free to delete anything that 
doesn't feel appropriate, and add anything additional 
that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->
Replace {{text}} with {{block}} in several places (where relevant)
Replace "method or function" with shortcode
Remove unnecessary new lines
Add "Annotated method style" to relevant Java/Kotlin code blocks.
Move {{ /block }} to after Ruby code examples for 2 blocks.
Adding some {{block}}s for "java,kotlin,scala" as needed.
Add white line between start of {{block}} and code block (unless there was text before the code block)
Fix typos
Remove redundant semicolons and {} in Kotlin examples.
Use shortcodes for stepdef-body and expression-parameter
Fix shortcode syntax where needed.


### ⚡️ What's your motivation? 

Consistency and looking to fix shortcodes
<!-- 
What motivated you to propose this change?

If it's related to another issue or bugfix, add it as a reference here, 
e.g. "Fixes cucumber/cucumber-js#99"
-->

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
