### PR TITLE
fix link of spring-java-junit5

### DIFF
--- a/content/docs/cucumber/state.md
+++ b/content/docs/cucumber/state.md
@@ -503,7 +503,7 @@ Feature: Let's write a lot of stuff to the DB
 
 ### With JUnit 5 and Spring
 {{% block "java,kotlin" %}} 
-See the [`spring-java-junit5`](https://github.com/cucumber/cucumber-jvm/tree/main/examples/spring-java-junit5) example in Cucumber-JVM for a minimal setup.
+See the [spring-java-junit5](https://github.com/cucumber/cucumber-jvm/tree/main/examples/spring-java-junit5) example in Cucumber-JVM for a minimal setup.
 {{% /block %}}
 
 {{% block "ruby,javascript" %}} JUnit 5 and Spring are used with JVM languages. {{% /block %}}


### PR DESCRIPTION
### 🤔 What's changed?

removed unncessary "`" from link syntax of spring-java-junit5

### ⚡️ What's your motivation? 

fix typo or something

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
