### PR TITLE
Updated broken link to cucumber jvm testng example

### DIFF
--- a/content/docs/cucumber/checking-assertions.md
+++ b/content/docs/cucumber/checking-assertions.md
@@ -82,7 +82,7 @@ If you are using Maven, add the following to your `pom.xml`:
 ```
 
 TestNG assertions are similar JUnit.
-For a more extensive example of how to use TestNG with Cucumber, see the [java-calculator-testng example](https://github.com/cucumber/cucumber-jvm/tree/main/examples/calculator-java-testng).
+For a more extensive example of how to use TestNG with Cucumber, see the [calculator-java-testng example](https://github.com/cucumber/cucumber-jvm/tree/main/examples/calculator-java-testng).
 
 For more information on how to use TestNG assertions, see the [TestNG documentation](https://testng.org/doc/documentation-main.html#success-failure).
 

--- a/content/docs/cucumber/checking-assertions.md
+++ b/content/docs/cucumber/checking-assertions.md
@@ -82,7 +82,7 @@ If you are using Maven, add the following to your `pom.xml`:
 ```
 
 TestNG assertions are similar JUnit.
-For a more extensive example of how to use TestNG with Cucumber, see the [java-calculator-testng example](https://github.com/cucumber/cucumber-jvm/tree/main/examples/java-calculator-testng).
+For a more extensive example of how to use TestNG with Cucumber, see the [java-calculator-testng example](https://github.com/cucumber/cucumber-jvm/tree/main/examples/calculator-java-testng).
 
 For more information on how to use TestNG assertions, see the [TestNG documentation](https://testng.org/doc/documentation-main.html#success-failure).
 


### PR DESCRIPTION
Seems the name of the folder has been changed from "java-calculator-testing" to "calculator-java-testng" resulting in a broken link. Updated.

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request 
if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here 
to help and will coach you through to getting your pull 
request ready to merge.

The prompts below are for guidance to help you describe 
your change in a way that is most likely to make sense 
to other people when they are reviewing it. Still, it's 
just a guide, so feel free to delete anything that 
doesn't feel appropriate, and add anything additional 
that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

The link to cucumber jvm examples has been updated

### ⚡️ What's your motivation? 

I was following the cucumber documentation for some testng examples, found the example link broken. Broken links ain't good :)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
