### PR TITLE
Remove Smart Bear Community recommendation

### DIFF
--- a/content/docs/community/get-in-touch.md
+++ b/content/docs/community/get-in-touch.md
@@ -20,7 +20,3 @@ Or just wander around and make yourself at home!
 # Stack Overflow
 
 Many people use the [`cucumber`](https://stackoverflow.com/questions/tagged/cucumber) and [`bdd`](https://stackoverflow.com/questions/tagged/bdd) tags on Stack Overflow to ask or answer questions about Cucumber.
-
-# SmartBear Community Forums
-
-The [Cucumber Forum](https://community.smartbear.com/t5/Cucumber-Open/bd-p/CucumberOS) on SmartBear's community forums is a good place to share your knowledge with others and hang out with other users from SmartBear's ecosystem.


### PR DESCRIPTION
We use GitHub to track issues and feature requests. When dealing with questions we direct people to the "Get In Touch Page". One of the options includes the Smart Bear Community.

Currently none of the question asked in the Smart Bear Community since the start of 2023 has received any reply. Nor have most of the questions in asked in 2022. 

Unfortunately because the Smart Bear Community does not provide answers people return with repeat questions e.g. https://github.com/cucumber/cucumber-jvm/issues/2723 and then  https://github.com/cucumber/cucumber-jvm/issues/2733.

It would make more sense to direct them to Stackoverflow and Slack exclusively. Questions are still answered there.

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request 
if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here 
to help and will coach you through to getting your pull 
request ready to merge.

The prompts below are for guidance to help you describe 
your change in a way that is most likely to make sense 
to other people when they are reviewing it. Still, it's 
just a guide, so feel free to delete anything that 
doesn't feel appropriate, and add anything additional 
that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change?

If it's related to another issue or bugfix, add it as a reference here, 
e.g. "Fixes cucumber/cucumber-js#99"
-->

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
