### PR TITLE
Doc changes to avoid user confusion of seperating tags with , in expr…

### DIFF
--- a/content/docs/cucumber/api.md
+++ b/content/docs/cucumber/api.md
@@ -969,6 +969,8 @@ A tag expression is an *infix boolean expression*. Below are some examples:
 | `@smoke and @fast`   |                   Scenarios tagged with both `@smoke` and `@fast` |
 | `@gui or @database`  |                Scenarios tagged with either `@gui` or `@database` |
 
+Note: Using a `,` to separate tags in expressions such as `@tag1,@tag2` will cause the entire expression to be parsed as a single tag, potentially leading to unintended outcomes. It's required to separate the tags with space or operators like `and` `or` and `not`.
+
 For even more advanced tag expressions you can use parenthesis for clarity, or
 to change operator precedence:
 


### PR DESCRIPTION
…ession

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request 
if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here 
to help and will coach you through to getting your pull 
request ready to merge.

The prompts below are for guidance to help you describe 
your change in a way that is most likely to make sense 
to other people when they are reviewing it. Still, it's 
just a guide, so feel free to delete anything that 
doesn't feel appropriate, and add anything additional 
that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

I came across https://github.com/cucumber/cucumber-jvm/issues/2776. Although the documentation specifies the expected format for tags, it seems that the pattern used by the user, 'https://github.com/Step1,@step2,' did not generate any error. This discrepancy has the potential to confuse users. To address this, it would be beneficial to add this message to doc

more discussion on this could be found in this [PR](https://github.com/cucumber/tag-expressions/pull/107)

### ⚡️ What's your motivation? 
heavily use this library, and wanted to contribute.


If it's related to another issue or bugfix, add it as a reference here, 
e.g. "Fixes cucumber/cucumber-js#99"
--> 
https://github.com/cucumber/cucumber-jvm/issues/2776
https://github.com/cucumber/tag-expressions/pull/107

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
