### PR TITLE
Add JUnit Formatter to CucumberJS Formatter List

### DIFF
--- a/content/docs/cucumber/reporting.md
+++ b/content/docs/cucumber/reporting.md
@@ -55,6 +55,7 @@ generate local reports using one of the following built-in reporter plugins (als
 * `rerun`
 * `snippets`
 * `usage`
+* `junit`
 
 There is also a "pretty" formatter available as an optional module [@cucumber/pretty-formatter](https://www.npmjs.com/package/@cucumber/pretty-formatter).
 {{% /block %}}


### PR DESCRIPTION

### 🤔 What's changed?

I add the `junit` formatter to the list of formatters available for CucumberJS.

### ⚡️ What's your motivation? 

CucumberJS now has support for the `junit` formatter and I want to make sure that the Cucumber documentation is up to date with available functionality.

https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md#junit

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
