### PR TITLE
Remove duplicated Kotlin stepDefinition example

### DIFF
--- a/content/docs/cucumber/step-definitions.md
+++ b/content/docs/cucumber/step-definitions.md
@@ -72,24 +72,6 @@ class StepDefinitions : En {
 
 {{% /block %}}
 
-{{% block "kotlin" %}}
-
-```kotlin
-package com.example
-import io.cucumber.java8.En
-
-class StepDefinitions : En {
-
-    init {
-        Given("I have {int} cukes in my belly") { cukes: Int ->
-                println("Cukes: $cukes")
-        }
-    }
-
-}
-```
-
-{{% /block %}}
 
 {{% block "scala" %}}
 


### PR DESCRIPTION
### 🤔 What's changed?
* remove duplicated kotlin stepDefinition example

### ⚡️ What's your motivation? 
* if you navigate to the https://cucumber.io/docs/cucumber/step-definitions/?lang=kotlin, you can check that there are duplicated first stepDefinition examples for Kotlin

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
