### PR TITLE
Specifically mention Scenario Outline descriptions can use parameters

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -427,6 +427,8 @@ The steps can use `<>` delimited *parameters* that reference headers in the exam
 Cucumber will replace these parameters with values from the table *before* it tries
 to match the step against a step definition.
 
+You can use parameters in `Scenario Outline` descriptions as well.
+
 You can also use parameters in [multiline step arguments](#step-arguments).
 
 # Step Arguments


### PR DESCRIPTION
### 🤔 What's changed?

- Specifically mention Scenario Outline descriptions can use parameters.

### ⚡️ What's your motivation?

I was unsure this was possible until I tried it out myself. Seems like useful information to call out. Makes each run of the outline have a unique name - including the value of the variable for that run - rather than multiple runs with the same exact name suffixed by a number.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
